### PR TITLE
Added missing field "postnom" for Zairians and Congolese, living after 1971.

### DIFF
--- a/specifications/conceptual-model-specification.md
+++ b/specifications/conceptual-model-specification.md
@@ -513,6 +513,7 @@ name | description | data type
 -----|-------------|----------
 familyName | The family name of the person. | [`http://www.w3.org/2000/01/rdf-schema#Literal`](#rdf-literal)
 givenName | The given name of the person. | [`http://www.w3.org/2000/01/rdf-schema#Literal`](#rdf-literal)
+postName | The post name of the person. | [`http://www.w3.org/2000/01/rdf-schema#Literal`](#rdf-literal)
 language | The language of the person. | [`http://www.w3.org/2000/01/rdf-schema#Literal`](#rdf-literal)
 
 
@@ -897,6 +898,7 @@ URI | description
 `http://gedcomx.org/Adoptive`|
 `http://gedcomx.org/Formal`|
 `http://gedcomx.org/Religious`|
+`http://gedcomx.org/PostName`|
 
 <a id="person"/>
 


### PR DESCRIPTION
In the Congo Free State / Belgian Congo / Congo / Democratic Republic of Congo under Belgian sample, there were:
- First name or Given Name (usually Christian, Christian name)
- Name (family name)

As part of the Zairianisation first names or given names have been banned as "imperialistic' and not "authentic" in 1971 (but in Christian families still used in private circumstances). The government (of Mobutu) introduced an new given name, the so-called 'After Name' or 'postnom' in French. Ergo, it was from around 1971/72:
- First name or Given Name (not officially, but de facto)
- Name (Family name)
- Postnom (officially, to replace the banned first name)

Since (Joseph Desire) Mobutu Sese Seko has been chased away in 1997, there are now many possibilities:
"first name" "family name"
"First name" "family name" "post name"
"family name" "post Name" (not everyone has a first name)

In the passports of the now Democratic Republic Congo (formerly Zaire) are three fields:
prénom = first name
nom = family name
postnom = post name (or "after name")

When Congolese people moves to the U.S., the postnom becomes the middle name; in Europe it is cut or  added to the family name as two-word-family-name.
Both are no solution for genealogy.
It concerns about 72 000 000 people in the D.R. Congo, 15 000 000 Congolese in the Diaspora and all those defunct Congolese/Zairian living in 1971 or afterwards.
