### PR TITLE
Are local-only "id" members necessary?  Why?

### DIFF
--- a/specifications/conceptual-model-specification.md
+++ b/specifications/conceptual-model-specification.md
@@ -293,6 +293,7 @@ The identifier for the "SourceDescription" data type is:
 
 name | description | data type
 -----|-------------|----------
+id | An identifier for the data structure holding the source description data. The id is to be used as a "fragment identifier" as defined by [RFC 3986, Section 3.5](http://tools.ietf.org/html/rfc3986#section-3.5). As such, the constraints of the id are provided in the definition of the media type (e.g. XML, JSON) of the data structure. | string
 citation | The citation for this source. | [`http://gedcomx.org/v1/SourceCitation`](#source-citation) - REQUIRED
 about | A uniform resource identifier (URI) for the resource being described. | [URI](#uri) - OPTIONAL
 mediator | A reference to the entity that mediates access to the described source. | [URI](#uri) - OPTIONAL; MUST resolve to an instance of [`http://gedcomx.org/v1/Agent`](#agent).
@@ -493,6 +494,7 @@ The identifier for the `Agent` data type is:
 
 name | description | data type
 -----|-------------|----------
+id | An identifier for the data structure holding the agent data. The id is to be used as a "fragment identifier" as defined by [RFC 3986, Section 3.5](http://tools.ietf.org/html/rfc3986#section-3.5). As such, the constraints of the id are provided in the definition of the media type (e.g. XML, JSON) of the data structure. | string
 identifiers | Identifiers for the agent. When an identifier for an agent is also an identifier for a person, the data in the person describes the agent. | List of [`http://gedcomx.org/v1/Identifier`](#identifier-type). Order is preserved.
 name | The name of the person or organization. | string
 homepage | The homepage of the person or organization. | [URI](#uri)
@@ -525,6 +527,7 @@ The identifier for the `Conclusion` data type is:
 
 name | description | data type
 -----|-------------|----------
+id | An identifier for the data structure holding the conclusion data. The id is to be used as a "fragment identifier" as defined by [RFC 3986, Section 3.5](http://tools.ietf.org/html/rfc3986#section-3.5). As such, the constraints of the id are provided in the definition of the media type (e.g. XML, JSON) of the data structure. | string
 sources | The list of references to the sources of related to this conclusion. The sources of a conclusion MUST also be sources of the conclusion's containing entity (i.e. [`Person`](#person) or [`Relationship`](#relationship) ).| List of [`http://gedcomx.org/v1/SourceReference`](#source-reference). Order is preserved.
 notes  | A list of notes about a conclusion. | List of [`http://gedcomx.org/Note`](#note) - OPTIONAL
 attribution | The attribution of this conclusion. | [`http://gedcomx.org/Attribution`](#attribution)

--- a/specifications/json-format-specification.md
+++ b/specifications/json-format-specification.md
@@ -333,6 +333,7 @@ data type is defined as follows:
 
 name | description | JSON member | JSON object type
 -----|-------------|--------------|---------
+id | An identifier for the JSON object holding the source description data. The id attribute MUST conform to the constraints defined in [Section 7, "Fragment Identifiers"](#fragment-ids). | id | string
 citation | The citation for this source | citation | [`SourceCitation`](#source-citation)
 about | A uniform resource identifier (URI) for the resource being described. | about | [`URI`](#uri)
 mediator | A reference to the entity that mediates access to the described source. | mediator | [`URI`](#uri)
@@ -501,6 +502,7 @@ The JSON object used to (de)serialize the `http://gedcomx.org/v1/Agent` data typ
 
 name | description | JSON member | JSON object type
 -----|-------------|--------------|---------
+id | An identifier for the JSON object holding the agent data. The id attribute MUST conform to the constraints defined in [Section 7, "Fragment Identifiers"](#fragment-ids). | id | string
 name | The name of the person or organization. | name | string
 identifiers | Identifiers for the agent. | identifiers | [`Identifier`](#identifier-type)
 homepage | The homepage of the person or organization. | homepage | [`URI`](#uri)
@@ -542,6 +544,7 @@ The JSON object used to (de)serialize the `http://gedcomx.org/v1/Conclusion` dat
 
 name | description | JSON member | JSON object type
 -----|-------------|--------------|---------
+id | An identifier for the JSON object holding the conclusion data. The id attribute MUST conform to the constraints defined in [Section 7, "Fragment Identifiers"](#fragment-ids). | id | string
 sources | The list of references to the sources of the conclusion. | sources | array of [`SourceReference`](#source-reference).
 notes | A list of notes about this conclusion. | note | array of [`gx:Note`](#note)
 attribution | The attribution of this conclusion. | attribution | [`gx:Attribution`](#attribution)
@@ -940,7 +943,9 @@ agents | array of [`Agent`](#agent)
 
 Fragment identifiers are used to identify specific objects (i.e. "fragments") within a JSON document. The GEDCOM X
 JSON serialization format specifies the use of the "id" member as the fragment identifier for any object in
-a given JSON document.
+a given JSON document. Note that some data types explicitly define an "id" property, but the JSON serialization format
+allows the option of an "id" property on _all_ objects for the purpose of identifying fragments of the JSON document.
+The values of all fragment identifiers within a single JSON document MUST be unique.
 
 For more information about fragment identifiers, see [RFC 3986, Section 3.5](http://tools.ietf.org/html/rfc3986#section-3.5).
 

--- a/specifications/xml-format-specification.md
+++ b/specifications/xml-format-specification.md
@@ -325,6 +325,7 @@ The `gx:SourceDescription` XML type is used to (de)serialize the
 
 name | description | XML property | XML type
 -----|-------------|--------------|---------
+id | An identifier for the XML element holding the source description data. The id attribute MUST conform to the constraints defined in [Section 7, "Fragment Identifiers"](#fragment-ids). | id (attribute) | xsd:string
 citation | The citation for this source | gx:citation | [`gx:SourceCitation`](#source-citation)
 about | A uniform resource identifier (URI) for the resource being described. | about (attribute) | [anyURI](#uri)
 mediator | A reference to the entity that mediates access to the described source. | gx:mediator | [`gx:ResourceReference`](#resource-reference)
@@ -516,6 +517,7 @@ data type.
 
 name | description | XML property | XML type
 -----|-------------|--------------|---------
+id | An identifier for the XML element holding the agent data. The id attribute MUST conform to the constraints defined in [Section 7, "Fragment Identifiers"](#fragment-ids). | id (attribute) | xsd:string
 identifiers | Identifiers for the agent. | gx:identifier | [`gx:Identifier`](#identifier-type)
 name | The name of the person or organization. | gx:name | xsd:string
 homepage | The homepage of the person or organization. | gx:homepage | [`gx:ResourceReference`](#resource-reference)
@@ -564,6 +566,7 @@ data type.
 
 name | description | XML property | XML type
 -----|-------------|--------------|---------
+id | An identifier for the XML element holding the conclusion data. The id attribute MUST conform to the constraints defined in [Section 7, "Fragment Identifiers"](#fragment-ids). | id (attribute) | xsd:string
 sources | A list of references to the sources of the conclusion. | gx:source | [`gx:SourceReference`](#source-reference)
 notes | A list of notes about this conclusion. | gx:note | [`gx:Note`](#note)
 attribution | The attribution of this conclusion. | gx:attribution | [`gx:Attribution`](#attribution)
@@ -1007,11 +1010,15 @@ gx:translationDocument | [`gx:TranslationDocument`](#translation-document)
 gx:analysisDocument | [`gx:AnalysisDocument`](#analysis-document)
 
 
+<a id="fragment-ids"/>
+
 7. Fragment Identifiers
 
 Fragment identifiers are used to identify specific elements (i.e. "fragments") within an XML document. The GEDCOM X
 XML serialization format specifies the use of the "id" attribute as the fragment identifier for any element in
-a given XML document.
+a given XML document. Note that some data types explicitly define an "id" attribute, but the XML serialization format
+allows the option of an "id" attribute on _all_ elements for the purpose of identifying fragments of the XML document.
+The values of all fragment identifiers within a single XML document MUST be unique.
 
 For more information about fragment identifiers, see [RFC 3986, Section 3.5](http://tools.ietf.org/html/rfc3986#section-3.5).
 


### PR DESCRIPTION
Many of the GEDCOM X entities have a local-only “id” member in their definition.  For entities that can be referenced by other entities (e.g. SourceDescription), this “id” seems potentially important.  For other entities that are only included by value (e.g., SourceReference), this “id” feels like overhead.

Is this “id” necessary?  If so, why?
