### PR TITLE
source reference qualifiers

### DIFF
--- a/specifications/conceptual-model-specification.md
+++ b/specifications/conceptual-model-specification.md
@@ -1096,7 +1096,8 @@ descriptionRef | A reference to a _description_ of this place. | [URI](#uri) | O
 
 ## 3.18 The "NamePart" Data Type
 
-The `NamePart` data type is used to model a portion of a full name, including the terms that make up that portion, and perhaps a name part qualifier (e.g., "given name" or "surname").
+The `NamePart` data type is used to model a portion of a full name, including the terms that make up that portion. Some name parts MAY have qualifiers
+to provide additional semantic meaning to the name part (e.g., "given name" or "surname").
 
 A name part value MAY contain more than one term from the full name, such as in the name part "John Fitzgerald" from the full name "John Fitzgerald Kennedy".  If multiple terms are
 detailed in a single `NamePart`, these terms are separated using the name separator appropriate to the locale of the name form.
@@ -1113,7 +1114,7 @@ name  | description | data type | constraints
 ------|-------------|-----------|------------
 type | URI identifying the type of the name part. | [URI](#uri) | OPTIONAL. If provided, MUST resolve to a name part type, and use of a [known name part type](#known-name-part-types) is RECOMMENDED.
 value | The term(s) from the name that make up this name part. | string | REQUIRED.
-qualifiers | Type qualifiers to further describe the type of the name part. | List of [URI](#uri) | OPTIONAL. If present, each qualifier MUST resolve to a name part type, and use of a [known name part type qualifier](#known-name-part-qualifier-types) is RECOMMENDED.
+qualifiers | Qualifiers to add additional semantic meaning to the name part. | List of [http://gedcomx.org/v1/Qualifier](#qualifier) | OPTIONAL. If present, use of a [known name part qualifier](#known-name-part-qualifier) is RECOMMENDED.
 
 <a id="known-name-part-types"/>
 
@@ -1128,29 +1129,29 @@ URI | description
 `http://gedcomx.org/Given`|
 `http://gedcomx.org/Surname`|
 
-<a id="known-name-part-qualifier-types"/>
+<a id="known-name-part-qualifier"/>
 
-### known name part qualifier types
+### Known Name Part Qualifiers
 
-The following name part qualifier types are defined by GEDCOM X:
+The following name part qualifiers are defined by GEDCOM X:
 
-URI | description
-----|-------------
-`http://gedcomx.org/Title`|A designation for honorifics (e.g. Dr., Rev., His Majesty, Haji), ranks (e.g. Colonel, General, Knight, Esquire), positions (e.g. Count, Chief, Father, King) or other titles (e.g., PhD, MD)
-`http://gedcomx.org/Primary`|A designation for the name of most prominent in importance among the names of that type (e.g., the primary given name).
-`http://gedcomx.org/Secondary`|A designation for a name that is not primary in its importance among the names of that type (e.g., a secondary given name).
-`http://gedcomx.org/Middle`|A designation useful for cultures that designate a middle name that is distinct from a given name and a surname.
-`http://gedcomx.org/Familiar`|A designation for one's familiar name.
-`http://gedcomx.org/Religious`|A designation for a name given for religious purposes.
-`http://gedcomx.org/Family`|A name that associates a person with a group, such as a clan, tribe, or patriarchal hierarchy.
-`http://gedcomx.org/Maiden`|A designation given by women to their original surname after they adopt a new surname upon marriage.
-`http://gedcomx.org/Patronymic`|A name derived from a father or paternal ancestor.
-`http://gedcomx.org/Matronymic`|A name derived from a mother or maternal ancestor.
-`http://gedcomx.org/Geographic`|A name derived from associated geography.
-`http://gedcomx.org/Occupational`|A name derived from one's occupation.
-`http://gedcomx.org/Characteristic`|A name derived from a characteristic.
-`http://gedcomx.org/Postnom`|A name mandedated by law populations from Congo Free State / Belgian Congo / Congo / Democratic Republic of Congo (formerly Zaire).
-`http://gedcomx.org/Particle`|A grammatical designation for articles (a, the, dem, las, el, etc.), prepositions (of, from, aus, zu, op, etc.), initials (e.g. PhD, MD), annotations (e.g. twin, wife of, infant, unknown), comparators (e.g. Junior, Senior, younger, little), ordinals (e.g. III, eighth), and conjunctions (e.g. and, or, nee, ou, y, o, ne, &amp;).
+name | description
+-----|-------------
+`http://gedcomx.org/Title`|A designation for honorifics (e.g. Dr., Rev., His Majesty, Haji), ranks (e.g. Colonel, General, Knight, Esquire), positions (e.g. Count, Chief, Father, King) or other titles (e.g., PhD, MD). The qualifier value SHOULD NOT be used.
+`http://gedcomx.org/Primary`|A designation for the name of most prominent in importance among the names of that type (e.g., the primary given name). The qualifier value SHOULD NOT be used.
+`http://gedcomx.org/Secondary`|A designation for a name that is not primary in its importance among the names of that type (e.g., a secondary given name). The qualifier value SHOULD NOT be used.
+`http://gedcomx.org/Middle`|A designation useful for cultures that designate a middle name that is distinct from a given name and a surname. The qualifier value SHOULD NOT be used.
+`http://gedcomx.org/Familiar`|A designation for one's familiar name. The qualifier value SHOULD NOT be used.
+`http://gedcomx.org/Religious`|A designation for a name given for religious purposes. The qualifier value SHOULD NOT be used.
+`http://gedcomx.org/Family`|A name that associates a person with a group, such as a clan, tribe, or patriarchal hierarchy. The qualifier value SHOULD NOT be used.
+`http://gedcomx.org/Maiden`|A designation given by women to their original surname after they adopt a new surname upon marriage. The qualifier value SHOULD NOT be used.
+`http://gedcomx.org/Patronymic`|A name derived from a father or paternal ancestor. The qualifier value SHOULD NOT be used.
+`http://gedcomx.org/Matronymic`|A name derived from a mother or maternal ancestor. The qualifier value SHOULD NOT be used.
+`http://gedcomx.org/Geographic`|A name derived from associated geography. The qualifier value SHOULD NOT be used.
+`http://gedcomx.org/Occupational`|A name derived from one's occupation. The qualifier value SHOULD NOT be used.
+`http://gedcomx.org/Characteristic`|A name derived from a characteristic. The qualifier value SHOULD NOT be used.
+`http://gedcomx.org/Postnom`|A name mandedated by law populations from Congo Free State / Belgian Congo / Congo / Democratic Republic of Congo (formerly Zaire). The qualifier value SHOULD NOT be used.
+`http://gedcomx.org/Particle`|A grammatical designation for articles (a, the, dem, las, el, etc.), prepositions (of, from, aus, zu, op, etc.), initials (e.g. PhD, MD), annotations (e.g. twin, wife of, infant, unknown), comparators (e.g. Junior, Senior, younger, little), ordinals (e.g. III, eighth), and conjunctions (e.g. and, or, nee, ou, y, o, ne, &amp;). The qualifier value SHOULD NOT be used.
 
 
 <a id="name-form"/>
@@ -1228,6 +1229,30 @@ NameForm3.parts[1].qualifiers[0]=http://gedcomx.org/Middle
 NameForm3.parts[2].type=http://gedcomx.org/Surname
 NameForm3.parts[2].value=Tchaikovsky
 ```
+
+<a id="qualifier"/>
+
+## 3.20 The "Qualifier" Data Type
+
+The `Qualifier` data type defines the data structure used to supply additional details, annotations, tags, or other qualifying data
+to a specific data element.
+
+### identifier
+
+The identifier for the "Qualifier" data type is:
+
+`http://gedcomx.org/v1/Qualifier`
+
+### properties
+
+name  | description | data type | constraints
+------|-------------|-----------|------------
+name | The name of the qualifier, used to determine the nature of the qualifier. | [URI](#uri) | REQUIRED. It is RECOMMENDED that the qualifier name resolve to an element of a constrained vocabulary.
+value | The value of the qualifier. The semantic meaning of the value is determined by the qualifier name. | string | OPTIONAL.
+
+### examples
+
+todo:
 
 
 # 4. Extensibility

--- a/specifications/conceptual-model-specification.md
+++ b/specifications/conceptual-model-specification.md
@@ -638,6 +638,22 @@ name  | description | data type | constraints
 ------|-------------|-----------|------------
 description  | Reference to a _description_ of the target source. | [URI](#uri) | REQUIRED. MUST resolve to an instance of [`http://gedcomx.org/v1/SourceDescription`](#source-description).
 attribution | The attribution of this source reference. | [`http://gedcomx.org/Attribution`](#attribution) | OPTIONAL. If not provided, the attribution of the containing resource of the source reference is assumed.
+qualifiers | Qualifiers for the reference, used to identify specific fragments of the source that are being referenced. | List of [http://gedcomx.org/v1/Qualifier](#qualifier) | OPTIONAL. If present, use of a [known source reference qualifier](#known-source-reference-qualifiers) is RECOMMENDED.
+
+<a id="known-source-reference-qualifiers"/>
+
+### Known Source Reference Qualifiers
+
+The following name part qualifiers are defined by GEDCOM X:
+
+name | value
+-----|-------
+`http://gedcomx.org/Page`|A page in a document.
+`http://gedcomx.org/Paragraph`|A paragraph in a document.
+`http://gedcomx.org/CharacterRegion`|A region of text in a digital document, in the form of `a,b` where `a` is the start character and `b` is the end character.
+`http://gedcomx.org/RectangleRegion`|A rectangular region of a digital image, in the form of `x,y,w,h` where `x` is the point on the X axis of the image in pixels, `y` is the point on the Y axis in pixels, `w` is the width of the rectangle in pixels, and `h` in the height of the rectangle in pixels.
+`http://gedcomx.org/PolygonRegion`|A polygon region of a digital image, in the form of `x,y,x,y...` where `x` is a point on the X axis of the image in pixels and `y` is a point on the Y axis in pixels.
+`http://gedcomx.org/TimeRegion`|A region of time of an audio or video recording, in the form of `a,b` where `a` is the starting point in milliseconds and `b` is the ending point in milliseconds.
 
 ### examples
 

--- a/specifications/conceptual-model-specification.md
+++ b/specifications/conceptual-model-specification.md
@@ -648,12 +648,9 @@ The following name part qualifiers are defined by GEDCOM X:
 
 name | value
 -----|-------
-`http://gedcomx.org/Page`|A page in a document.
-`http://gedcomx.org/Paragraph`|A paragraph in a document.
-`http://gedcomx.org/CharacterRegion`|A region of text in a digital document, in the form of `a,b` where `a` is the start character and `b` is the end character.
-`http://gedcomx.org/RectangleRegion`|A rectangular region of a digital image, in the form of `x,y,w,h` where `x` is the point on the X axis of the image in pixels, `y` is the point on the Y axis in pixels, `w` is the width of the rectangle in pixels, and `h` in the height of the rectangle in pixels.
-`http://gedcomx.org/PolygonRegion`|A polygon region of a digital image, in the form of `x,y,x,y...` where `x` is a point on the X axis of the image in pixels and `y` is a point on the Y axis in pixels.
-`http://gedcomx.org/TimeRegion`|A region of time of an audio or video recording, in the form of `a,b` where `a` is the starting point in milliseconds and `b` is the ending point in milliseconds.
+`http://gedcomx.org/CharacterRegion`|A region of text in a digital document, in the form of `a,b` where `a` is the start character and `b` is the end character. The meaning of this qualifier is undefined if the source being referenced is not a digital document.
+`http://gedcomx.org/RectangleRegion`|A rectangular region of a digital image, in the form of `x,y,w,h` where `x` is the point on the X axis of the image in pixels, `y` is the point on the Y axis in pixels, `w` is the width of the rectangle in pixels, and `h` in the height of the rectangle in pixels. The meaning of this qualifier is undefined if the source being referenced is not a digital image.
+`http://gedcomx.org/TimeRegion`|A region of time of a digital audio or video recording, in the form of `a,b` where `a` is the starting point in milliseconds and `b` is the ending point in milliseconds. The meaning of this qualifier is undefined if the source being referenced is not a digital audio or video recording.
 
 ### examples
 

--- a/specifications/json-format-specification.md
+++ b/specifications/json-format-specification.md
@@ -678,13 +678,15 @@ name | description | JSON member | JSON object type
 -----|-------------|--------------|---------
 descriptionRef  | Reference to a _description_ of the source being referenced. | description | [`URI`](#uri)
 attribution | The attribution of this source reference. | attribution | [`Attribution`](#attribution)
+qualifiers | Qualifiers for the reference, used to identify specific fragments of the source that are being referenced. | qualifiers | array of [`Qualifier`](#qualifier)
 
 ### examples
 
 ```json
 {
   "description" : "http://identifier/for/description/of/source/being/referenced",
-  "attribution" : { ... }
+  "attribution" : { ... },
+  "qualifiers" : [ { "name" : "http://gedcomx.org/Page", "value" : "..." } , { "name" : "http://gedcomx.org/Paragraph", "value" : "..." } ],
 
   ...possibility of extension elements...
 

--- a/specifications/json-format-specification.md
+++ b/specifications/json-format-specification.md
@@ -957,7 +957,7 @@ name | description | JSON member | JSON object type
 -----|-------------|--------------|---------
 type | URI identifying the type of the name part. | type | [`URI`](#uri)
 value | The text of the name part. | value | string
-qualifiers | Type qualifiers to further describe the type of the name part. | qualifiers | array of [`ResourceReference`](#resource-reference)
+qualifiers | Type qualifiers to further describe the type of the name part. | qualifiers | array of [`Qualifier`](#qualifier)
 
 ### examples
 
@@ -965,7 +965,7 @@ qualifiers | Type qualifiers to further describe the type of the name part. | qu
 {
   "type" : "http://gedcomx.org/Prefix",
   "value" : "...value of the name part..."
-  "qualifiers" : [ { "resource" : "http://gedcomx.org/Family" }, { "resource" : "http://gedcomx.org/Patronymic" } ]
+  "qualifiers" : [ { "name" : "http://gedcomx.org/Family" }, { "name" : "http://gedcomx.org/Patronymic" } ]
 
   ...possibility of extension elements...
 
@@ -994,6 +994,27 @@ parts | The parts of the name form. | parts | array of [`NamePart`](#name-part)
 
   ...possibility of extension elements...
 
+}
+```
+<a id="qualifier"/>
+
+## 3.20 The "Qualifier" Data Type
+
+The JSON object used to (de)serialize the `http://gedcomx.org/v1/Qualifier` data type is defined as follows:
+
+### properties
+
+name | description | JSON member | JSON object type
+-----|-------------|-------------|---------
+name | The name of the qualifier, used to determine the nature of the qualifier. | name | [`URI`](#uri)
+value | The value of the qualifier. The semantic meaning of the value is determined by the qualifier name. | value | string
+
+### examples
+
+```json
+{
+  "name" : "http://gedcomx.org/QualifierName",
+  "value" : "..."
 }
 ```
 

--- a/specifications/xml-format-specification.md
+++ b/specifications/xml-format-specification.md
@@ -970,13 +970,13 @@ name | description | XML property | XML type
 -----|-------------|--------------|---------
 type | URI identifying the type of the name part. | type (attribute) | [`URI`](#uri)
 value | The text of the name part. | value (attribute) | xsd:string
-qualifiers | Type qualifiers to further describe the type of the name part. | gx:qualifier | [`gx:ResourceReference`](#resource-reference)
+qualifiers | Qualifiers to add additional semantic meaning to the name part. | gx:qualifier | [`gx:Qualifier`](#qualifier)
 
 ### examples
 
 ```xml
   <... type="http://gedcomx.org/Prefix" value="...value of the name part...">
-    <qualifier resource="http://gedcomx.org/First"/>
+    <qualifier name="http://gedcomx.org/First"/>
     ...
 
     <!-- possibility of extension elements -->
@@ -1013,6 +1013,26 @@ parts | Any identified name parts from the name represented in this instance, or
     <!-- possibility of extension elements -->
 
   </...>
+```
+
+<a id="qualifier"/>
+
+## 3.20 The "Qualifier" Data Type
+
+The `Qualifier` XML type is used to (de)serialize the `http://gedcomx.org/v1/Qualifier`
+data type.
+
+### properties
+
+name | description | XML property | XML type
+-----|-------------|--------------|---------
+name | The name of the qualifier, used to determine the nature of the qualifier. | name (attribute) | [anyURI](#uri)
+value | The value of the qualifier. The semantic meaning of the value is determined by the qualifier name. | (child text) | xsd:string
+
+### examples
+
+```xml
+  <... name="http://gedcomx.org/QualifierName">...qualifier value...</...>
 ```
 
 # 4 XML-Specific Data Types

--- a/specifications/xml-format-specification.md
+++ b/specifications/xml-format-specification.md
@@ -672,6 +672,7 @@ name | description | XML property | XML type
 -----|-------------|--------------|---------
 descriptionRef  | Reference to a _description_ of the source being referenced. | description (attribute) | [`URI`](#uri)
 attribution | The attribution of this source reference. | gx:attribution | [`gx:Attribution`](#attribution)
+qualifiers | Qualifiers for the reference, used to identify specific fragments of the source that are being referenced. | gx:qualifier | [`gx:Qualifier`](#qualifier)
 
 ### examples
 
@@ -680,6 +681,9 @@ attribution | The attribution of this source reference. | gx:attribution | [`gx:
     <gx:attribution>
       ...
     </gx:attribution>
+    <gx:qualifier name="http://gedcomx.org/Page">...</gx:qualifier>
+    <gx:qualifier name="http://gedcomx.org/Paragraph">...</gx:qualifier>
+    ...
 
     <!-- possibility of extension elements -->
 


### PR DESCRIPTION
We've identified the need to provide additional "qualifiers" on a source reference. Examples of source reference qualifiers include:
- Providing a page and paragraph on a citation to a document.
- Identifying a specific region (i.e. "bounding box") on a citation to a digital image.
- Identifying a specific segment on a citation to an audio or video recording.

Your comments are invited on the attached proposed changes. The changes can be summarized as adding a "qualifiers" property to the source reference object. A qualifier is basically just a name-value pair, the name being an element of a constrained vocabulary. The following source reference qualifiers are also specified:

| name | value |
| --- | --- |
| `http://gedcomx.org/Page` | A page in a document. |
| `http://gedcomx.org/Paragraph` | A paragraph in a document. |
| `http://gedcomx.org/CharacterRegion` | A region of text in a digital document, in the form of `a,b` where `a` is the start character and `b` is the end character. |
| `http://gedcomx.org/RectangleRegion` | A rectangular region of a digital image, in the form of `x,y,w,h` where `x` is the point on the X axis of the image in pixels, `y` is the point on the Y axis in pixels, `w` is the width of the rectangle in pixels, and `h` in the height of the rectangle in pixels. |
| `http://gedcomx.org/PolygonRegion` | A polygon region of a digital image, in the form of `x,y,x,y...` where `x` is a point on the X axis of the image in pixels and `y` is a point on the Y axis in pixels. |
| `http://gedcomx.org/TimeRegion` | A region of time of an audio or video recording, in the form of `a,b` where `a` is the starting point in milliseconds and `b` is the ending point in milliseconds. |
