### PR TITLE
Citation template requirements update

### DIFF
--- a/specifications/citation-template-model-specificaiton.md
+++ b/specifications/citation-template-model-specificaiton.md
@@ -1,0 +1,276 @@
+# The GEDCOM X Citation Template Model
+
+## Status
+
+This document defines the concept of a "Citation Template" and specifies how the GEDCOM X Conceptual Model,
+the GEDCOM X XML Format, and the GEDCOM X JSON Format are to be extended to support citation templates.
+The current state of this document is as a DRAFT, and as such, the document may be subject to changes,
+including backwards-incompatible changes, according to the discussion and suggestions for improvement.
+
+## Copyright Notice
+
+Copyright 2011-2013 Intellectual Reserve, Inc.
+
+## License
+
+This document is distributed under a Creative Commons Attribution-ShareAlike license.
+For details, see:
+
+http://creativecommons.org/licenses/by-sa/3.0/
+
+# 1. Introduction
+
+Building source citations is said to be an "art" and requires a great deal of flexibility.  While source citation style guides
+exist (e.g. Chicago Manual of Style, etc.), execution within their guidelines is flexible.  As no one citation style enjoys
+universal acceptance, the GEDCOM X Citation Template Model defines the concept of "citation templates" to allow a variety of
+citation styles to coexist and to be exchanged.
+
+Within a given citation style, citation information is formed into "variants" as the context of the citation varies. For example,
+the citation formed for a document's first footnote can be different from the citation formed for the same document in a subsequent
+footnote, and again different from the citation formed when it appears in a source list at the end of the same document.
+
+Source citations are hard for even the most diligent genealogists.  Recent industry efforts toward making citation creation
+approachable for a typical genealogist have been focused on making citations easy to create in very well-defined and specific
+circumstances (i.e., on a per-record-set or per-artifact-type basis), not in finding a one-size-fits-all solution.  The needs
+seem to be for mechanisms that hide the complexity of forming a citation in favor of mechanisms that collect fielded information
+that a user can readily identify and then providing automation to form the various citation variants (e.g., source list entry,
+first reference note, subsequent reference, etc.) within a selected citation style (e.g., Chicago Manual of Style) using this
+fielded data as required by circumstance.
+
+In support of the variations in style and context, citation information is collected in pieces, hereby referred to as "citation
+fields".  These citation fields can be formed and reformed to produce the variants within a particular style, and perhaps even be
+formed into citations in alternate styles.
+
+Citation templates are intended to be a framework within which vendors and standards organizations declare the citation fields
+that can be collected about a given type of source -- a controlled vocabulary that defines acceptable fields, field value ranges
+and syntax, and any semantic meaning.  Citation templates are also used to declare how the fields are formed into citations (each
+variant addressable by a combination of style and variant identifiers). Separate citation templates could be provided for
+specific record types (e.g. a template for an online image in the 1910 United States Census) and could be associated with other
+templates according to the record type (e.g. a group of templates for newspapers, US census records, UK census records, etc.).
+Citation templates could also be bundled with other templates into "template libraries" such that nuances in semantic meaning of
+a specific citation field (e.g. "Volume") are shared among all the associated templates. Perhaps a standard template library
+could be developed to address the most common citation needs.
+
+## 1.1 Identifier, Version, and Dependencies
+
+The identifier for this specification is:
+
+`http://gedcomx.org/citaton-template-model/v1`
+
+This specification depends on and extends the conceptual model specification identified
+by [`http://gedcomx.org/conceptual-model/v1`](https://github.com/FamilySearch/gedcomx/blob/master/specifications/conceptual-model-specification.md).
+
+This specification depends on and extends the XML serialization format specification identified
+by [`http://gedcomx.org/xml/v1`](https://github.com/FamilySearch/gedcomx/blob/master/specifications/xml-format-specification.md).
+
+This specification depends on and extends JSON xml serialization format specification identified
+by [`http://gedcomx.org/json/v1`](https://github.com/FamilySearch/gedcomx/blob/master/specifications/json-format-specification.md).
+
+## 1.2 Notational Conventions
+
+### 1.2.1 Keywords
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+"SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in BCP 14,
+[RFC2119](http://tools.ietf.org/html/rfc2119), as scoped to those conformance
+targets.
+
+# 2. Data Type Extensions
+
+This section defines new data types and new extension properties on existing data types
+for support of citation templates.
+
+<a id="citation-template"/>
+
+## 2.1 The "CitationTemplate" Data Type
+
+The `CitationTemplate` data type defines a citation template.
+
+### identifier
+
+The identifier for the `CitationTemplate` data type is:
+
+`http://gedcomx.org/v1/CitationTemplate`
+
+### constraints
+
+A citation template data type MUST conform to the following provisions:
+
+* A citation template MUST provide a globally unique identifier.
+* A citation template MUST declare the citation fields that can be used to form a citation, including which fields are optional and which are required.
+* A citation template MUST provide rendering definitions for each relevant citation variant, including:
+  * REQUIRED identifier for each citation variant.
+  * REQUIRED specification for rendering citation field values into a citation for each citation variant; each rendering specification MUST include any text formatting requirements (e.g. italics).
+  * OPTIONAL identifier(s) for the citation style of each citation variant.
+  * OPTIONAL titles for each variant (including support for alternate languages)
+* A citation template SHOULD provide self-descriptive metadata, such as:
+  * identifiers (e.g., template library identifiers)
+  * titles (including support for alternate languages)
+  * descriptions (including support for alternate languages)
+  * keywords for finding and associating relevant templates
+* A citation template SHOULD provide information to assist applications in collecting citation field values, such as:
+  * display names for citation fields (including support for alternate languages)
+  * hints for the citation field values (including support for alternate languages)
+  * validation criteria for citation field values
+
+### extension
+
+todo:
+
+### properties
+
+todo:
+
+
+<a id="citation-field"/>
+
+## 2.2 The "CitationField" Data Type
+
+The `CitationField` data type defines a piece of metadata (e.g., author, volume, page, publisher, etc.)
+necessary to identify a source.
+
+The `CitationField` data type does NOT support extension properties.
+
+### identifier
+
+The identifier for the "CitationField" data type is:
+
+`http://gedcomx.org/v1/CitationField`
+
+### properties
+
+name  | description | data type | constraints
+------|-------------|-----------|------------
+name | The identifier for the citation detail -- defined by a citation template or a citation template library. | [URI](#uri) | REQUIRED.
+value | The value of the citation detail. | string | REQUIRED.
+
+## 2.3 Extension Properties to the "SourceCitation" Data Type
+
+The following extension properties are defined as applicable to the [`http://gedcomx.org/v1/SourceCitation`](#source-citation) data type.
+
+name  | description | data type | constraints
+------|-------------|-----------|------------
+citationTemplate | The identifier of the citation template by which this citation may be interpreted. | [URI](#uri) | OPTIONAL. If provided, MUST resolve to an instance of [`http://gedcomx.org/v1/CitationTemplate`](#citation-template).
+fields  | A list of citation fields about a source. | List of [`http://gedcomx.org/v1/CitationField`](#citation-field) | OPTIONAL.
+
+
+# 3. XML Serialization Format
+
+This section specifies how the [XML serialization format](https://github.com/FamilySearch/gedcomx/blob/master/specifications/xml-format-specification.md)
+is extended to support the data types and extension properties for citation templates.
+
+### namespace prefixes
+
+This document uses the following namespace prefixes:
+
+prefix | namespace
+-------|----------
+gx | `http://gedcomx.org/v1/`
+xsd | `http://www.w3.org/2001/XMLSchema`
+
+<a id="citation-template"/>
+
+## 3.1 The "CitationTemplate" Data Type
+
+todo:
+
+<a id="citation-field"/>
+
+## 3.2 The "CitationField" Data Type
+
+The `gx:CitationField` XML type is used to (de)serialize the
+`http://gedcomx.org/v1/CitationField` data type.
+
+### properties
+
+name | description | XML property | XML type
+-----|-------------|--------------|---------
+name | The identifier for the citation detail -- defined by a citation template or a citation template library. | gx:name | [anyURI](https://github.com/FamilySearch/gedcomx/blob/master/specifications/xml-format-specification.md#uri)
+value | A rendering of the full (working) citation as a string. | gx:value | xsd:string
+
+### examples
+
+```xml
+  <... name="...a citation field name...">...a citation field value...</...>
+```
+
+## 3.3 Extension Properties to the "SourceCitation" Data Type
+
+### properties
+
+name | description | XML property | XML type
+-----|-------------|--------------|---------
+citationTemplate | The identifier of the citation template by which this citation may be interpreted. | gx:citationTemplate | [`gx:ResourceReference`](#resource-reference)
+fields | A list of citation fields about a source. | gx:field | [`gx:CitationField`](#citation-field)
+
+### examples
+
+```xml
+  <... xml:lang="en">
+    <gx:value>...a rendering of the full (working) citation as a string...</gx:value>
+    <gx:citationTemplate resource="http://identifier/for/ciation/template"/>
+    <gx:field>
+      ...
+    </gx:field>
+    ...
+  </...>
+```
+
+
+# 4. JSON Serialization Format
+
+This section specifies how the [JSON serialization format](https://github.com/FamilySearch/gedcomx/blob/master/specifications/json-format-specification.md)
+is extended to support the data types and extension properties for citation templates.
+
+
+<a id="citation-template"/>
+
+## 4.1 The "CitationTemplate" Data Type
+
+todo:
+
+<a id="citation-field"/>
+
+## 4.2 The "CitationField" Data Type
+
+The JSON object used to (de)serialize the
+`http://gedcomx.org/v1/CitationField` data type is defined as follows:
+
+### properties
+
+name | description | XML property | XML type
+-----|-------------|--------------|---------
+name | The identifier for the citation detail -- defined by a citation template or a citation template library. | name | [URI](https://github.com/FamilySearch/gedcomx/blob/master/specifications/json-format-specification.md#uri)
+value | The value of the citation detail. | value | string
+
+### examples
+
+```json
+{
+  "name" : "...a citation field name..."
+  "value" : "...a citation field value..."
+}
+```
+
+## 4.3 Extension Properties to the "SourceCitation" Data Type
+
+### properties
+
+name | description | XML property | XML type
+-----|-------------|--------------|---------
+citationTemplate | The identifier of the citation template by which this citation may be interpreted. | citationTemplate | [`ResourceReference`](#resource-reference)
+fields | A list of citation fields about a source. | field | array of [`CitationField`](#citation-field)
+
+### examples
+
+```json
+{
+  "lang" : "en",
+  "value" : "...a rendering of the full (working) citation as a string...",
+  "citationTemplate" : {
+    "resource" : "http://identifier/for/ciation/template"
+  },
+  "fields" : [ { ... }, { ... } ]
+}
+```

--- a/specifications/conceptual-model-specification.md
+++ b/specifications/conceptual-model-specification.md
@@ -595,82 +595,11 @@ name  | description | data type | constraints
 ------|-------------|-----------|------------
 lang | The locale identifier for the citation. | [IETF BCP 47](http://tools.ietf.org/html/bcp47) locale tag | OPTIONAL. If not provided, the locale of the data set containing the citation is assumed.
 value | A rendering of the full (working) citation as a string. | string | REQUIRED.
-citationTemplate | The identifier of the citation template by which this citation may be interpreted. | [URI](#uri) | OPTIONAL. If provided, MUST resolve to an instance of a citation template that conforms to the specifications defined in [Section 3.5.1, Citation Templates](#citation-template).
-fields  | A list of citation fields about a source. | List of [`http://gedcomx.org/v1/CitationField`](#citation-field) | OPTIONAL.
-
-### 3.5.1 Citation Templates
-
-Building source citations is said to be an "art" and requires a great deal of flexibility.  While citation style guides
-exist (e.g. Chicago style, Turabian style, etc.), execution within their guidelines allows for flexibility.  As no one style
-enjoys universal acceptance, the GEDCOM X defines the concept of "citation templates" to allow a variety of citation
-styles to coexist.
-
-Within a single citation style, citation information is transformed into citations differently as the usage context varies.
-For example, the citation rendered for a source's first footnote can be different from the citation rendered for the same source
-in a subsequent footnote, and again different from the citation rendered for that same source when it appears in a source
-listing.
-
-In support of the variations in style and context-specific renderings, citation information is collected in pieces,
-hereby referred to as "citation fields".  Citation information in the form of citation fields can be formed and reformed
-to produce the variants within a particular style, and perhaps even be rendered as citations in alternate styles.
-
-Citation templates are used to declare the citation fields that can be collected about a given source -- a controlled vocabulary
-that defines acceptable fields, field value ranges and syntax, and any semantic meaning. Citation templates are also used to
-declare how the fields are rendered into citations. Separate citation templates could be provided to for specific record types
-(e.g. how to cite an online image for the 1910 United States Census) and could be associated with other templates according to the
-record type (e.g. a group of templates for census records, newspapers, US census records, UK census records, etc.).  Citation
-templates could also be bundled with other templates into "template libraries" such that nuances in semantic meaning of a specific
-citation field (e.g. "Volume") are shared among the associated templates. Perhaps a standard template library could be developed
-to address the most common citation needs.
-
-The definition of a formal citation template data type is outside the scope of this specification. A citation template
-referenced by GEDCOM X `SourceCitation` data type SHOULD conform to the following provisions:
-
-* A citation template MUST provide a globally unique identifier.
-* A citation template MUST declare the citation fields that can be used to form a citation, including which fields are
-  optional and which are required.
-* A citation template MUST provide rendering definitions for each relevant citation variant, including:
-  * REQUIRED identifier for each citation variant.
-  * REQUIRED specification for rendering citation field values into a citation for each citation variant; each rendering specification MUST include any text formatting requirements (e.g. italics).
-  * OPTIONAL identifier(s) for the citation style of each citation variant.
-  * OPTIONAL titles for each variant (including support for alternate languages)
-* A citation template SHOULD provide self-descriptive metadata, such as:
-  * identifiers (e.g., template library identifiers)
-  * titles (including support for alternate languages)
-  * descriptions (including support for alternate languages)
-  * keywords for finding and associating relevant templates
-* A citation template SHOULD provide information to assist applications in collecting citation field values, such as:
-  * display names for citation fields (including support for alternate languages)
-  * hints for the citation field values (including support for alternate languages)
-  * validation criteria for citation field values
-
-
-<a id="citation-field"/>
-
-## 3.6 The "CitationField" Data Type
-
-The `CitationField` data type defines a piece of metadata (e.g., author, volume, page, publisher, etc.)
-necessary to identify a source.
-
-The `CitationField` data type does NOT support extension properties (see [Extension Properties](#extension-properties)).
-
-### identifier
-
-The identifier for the "CitationField" data type is:
-
-`http://gedcomx.org/v1/CitationField`
-
-### properties
-
-name  | description | data type | constraints
-------|-------------|-----------|------------
-name | The identifier for the citation detail -- defined by a citation template or a citation template library. | [URI](#uri) | REQUIRED.
-value | The value of the citation detail. | string | REQUIRED.
 
 
 <a id="source-reference"/>
 
-## 3.7 The "SourceReference" Data Type
+## 3.6 The "SourceReference" Data Type
 
 The `SourceReference` data type defines a reference to a source.  For example a genealogical conclusion
 or a derivative source is the referring object (i.e. the object holding the `SourceReference` instance),
@@ -695,7 +624,7 @@ todo:
 
 <a id="online-account"/>
 
-## 3.8 The "OnlineAccount" Data Type
+## 3.7 The "OnlineAccount" Data Type
 
 The `OnlineAccount` data type defines a description of an account in an online web application.
 
@@ -714,7 +643,7 @@ accountName | The name, label, or id associating the owner of the account with t
 
 <a id="address"/>
 
-## 3.9 The "Address" Data Type
+## 3.8 The "Address" Data Type
 
 The `Address` data type defines a street address of a person or organization.
 
@@ -743,7 +672,7 @@ street6 | The street (sixth line). | string | OPTIONAL.
 
 <a id="conclusion"/>
 
-## 3.10 The "Conclusion" Data Type
+## 3.9 The "Conclusion" Data Type
 
 The `Conclusion` data type defines the base conceptual model for basic genealogical conclusions.
 
@@ -765,7 +694,7 @@ notes  | A list of notes about a conclusion. | List of [`http://gedcomx.org/Note
 
 <a id="known-confidence-levels"/>
 
-### 3.10.1 Known Confidence Levels
+### 3.9.1 Known Confidence Levels
 
 The following confidence levels are defined by GEDCOM X.
 
@@ -778,7 +707,7 @@ URI | description
 
 <a id="gender-conclusion"/>
 
-## 3.11 The "Gender" Data Type
+## 3.10 The "Gender" Data Type
 
 The `Gender` data type defines a conclusion about the gender of a person.
 
@@ -803,7 +732,7 @@ type  | URI identifying the type of the gender. | [URI](#uri) | REQUIRED. MUST r
 
 <a id="known-gender-types"/>
 
-### 3.11.1 Known Gender Types
+### 3.10.1 Known Gender Types
 
 The following gender types are defined by GEDCOM X:
 
@@ -816,7 +745,7 @@ URI | description
 
 <a id="name-conclusion"/>
 
-## 3.12 The "Name" Data Type
+## 3.11 The "Name" Data Type
 
 The `Name` data type defines a conclusion about a name of a person.
 
@@ -880,7 +809,7 @@ Name2.nameForms[1].fullText=Sasha
 ```
 <a id="known-name-types"/>
 
-### 3.12.1 Known Name Types
+### 3.11.1 Known Name Types
 
 The following name types are defined by GEDCOM X:
 
@@ -898,7 +827,7 @@ URI | description
 
 <a id="fact-conclusion"/>
 
-## 3.13 The "Fact" Data Type
+## 3.12 The "Fact" Data Type
 
 The `Fact` data type defines a conclusion about a fact of the life of a person or
 the nature of a relationship. The `Fact` data type extends the `Conclusion` data type.
@@ -927,7 +856,7 @@ qualifiers | Qualifiers to add additional details about the fact. | List of [htt
 
 <a id="known-fact-types"/>
 
-### 3.13.1 Known Fact Types
+### 3.12.1 Known Fact Types
 
 The following fact types are defined by GEDCOM X:
 
@@ -1004,7 +933,7 @@ URI | description | scope
 
 <a id="known-fact-qualifier"/>
 
-### 3.14.2 Known Fact Qualifiers
+### 3.12.2 Known Fact Qualifiers
 
 The following fact qualifiers are defined by GEDCOM X:
 
@@ -1016,7 +945,7 @@ name | value
 
 <a id="conclusion-event-role"/>
 
-## 3.14 The "EventRole" Data Type
+## 3.13 The "EventRole" Data Type
 
 The `EventRole` data type defines a role played in an event by a person.  The `EventRole` data type extends the `Conclusion` data type.
 
@@ -1042,7 +971,7 @@ details | Details about the role of the person in the event. | string | OPTIONAL
 
 <a id="known-roles"/>
 
-### 3.14.1 Known Role Types
+### 3.13.1 Known Role Types
 
 The following role types are defined by GEDCOM X:
 
@@ -1056,7 +985,7 @@ URI | description
 
 <a id="conclusion-date"/>
 
-## 3.15 The "Date" Data Type
+## 3.14 The "Date" Data Type
 
 The `Date` data type defines the value of a genealogical date.
 
@@ -1076,7 +1005,7 @@ formal | The standardized [formal value](#formal-values) of the date, formatted 
 
 <a id="conclusion-place-reference"/>
 
-## 3.16 The "PlaceReference" Data Type
+## 3.15 The "PlaceReference" Data Type
 
 The `PlaceReference` data type defines a reference to a description of a place.
 
@@ -1096,7 +1025,7 @@ descriptionRef | A reference to a _description_ of this place. | [URI](#uri) | O
 
 <a id="name-part"/>
 
-## 3.17 The "NamePart" Data Type
+## 3.16 The "NamePart" Data Type
 
 The `NamePart` data type is used to model a portion of a full name, including the terms that make up that portion. Some name parts MAY have qualifiers
 to provide additional semantic meaning to the name part (e.g., "given name" or "surname").
@@ -1120,7 +1049,7 @@ qualifiers | Qualifiers to add additional semantic meaning to the name part. | L
 
 <a id="known-name-part-types"/>
 
-### 3.17.1 Known Name Part Types
+### 3.16.1 Known Name Part Types
 
 The following name part types are defined by GEDCOM X:
 
@@ -1158,7 +1087,7 @@ name | description
 
 <a id="name-form"/>
 
-## 3.18 The "NameForm" Data Type
+## 3.17 The "NameForm" Data Type
 
 The `NameForm` data type defines a representation of a name (a "name form") within a given cultural context,
 such as a given language and script.
@@ -1234,7 +1163,7 @@ NameForm3.parts[2].value=Tchaikovsky
 
 <a id="qualifier"/>
 
-## 3.20 The "Qualifier" Data Type
+## 3.18 The "Qualifier" Data Type
 
 The `Qualifier` data type defines the data structure used to supply additional details, annotations, tags, or other qualifying data
 to a specific data element.

--- a/specifications/json-format-specification.md
+++ b/specifications/json-format-specification.md
@@ -633,8 +633,6 @@ name | description | XML property | XML type
 -----|-------------|--------------|---------
 lang | The locale identifier for the citation. | lang | [IETF BCP 47](http://tools.ietf.org/html/bcp47) locale tag
 value | A rendering of the full (working) citation as a string. | value | string
-citationTemplate | The identifier of the citation template by which this citation may be interpreted. | citationTemplate | [`ResourceReference`](#resource-reference)
-fields | A list of citation fields about a source. | field | array of [`CitationField`](#citation-field)
 
 ### examples
 
@@ -642,39 +640,15 @@ fields | A list of citation fields about a source. | field | array of [`Citation
 {
   "lang" : "en",
   "value" : "...a rendering of the full (working) citation as a string...",
-  "citationTemplate" : {
-    "resource" : "http://identifier/for/ciation/template"
-  },
-  "fields" : [ { ... }, { ... } ]
-}
-```
 
-<a id="citation-field"/>
+  ...possibility of extension elements...
 
-## 3.6 The "CitationField" Data Type
-
-The JSON object used to (de)serialize the
-`http://gedcomx.org/v1/CitationField` data type is defined as follows:
-
-### properties
-
-name | description | XML property | XML type
------|-------------|--------------|---------
-name | The identifier for the citation detail -- defined by a citation template or a citation template library. | name | [URI](#uri)
-value | The value of the citation detail. | value | string
-
-### examples
-
-```json
-{
-  "name" : "...a citation field name..."
-  "value" : "...a citation field value..."
 }
 ```
 
 <a id="source-reference"/>
 
-## 3.7 The "SourceReference" Data Type
+## 3.6 The "SourceReference" Data Type
 
 The JSON object used to (de)serialize the `http://gedcomx.org/v1/SourceReference`
 data type is defined as follows:
@@ -700,7 +674,7 @@ attribution | The attribution of this source reference. | attribution | [`Attrib
 
 <a id="online-account"/>
 
-## 3.8 The "OnlineAccount" Data Type
+## 3.7 The "OnlineAccount" Data Type
 
 The JSON object used to (de)serialize the `http://gedcomx.org/v1/OnlineAccount` data type is defined as follows:
 
@@ -724,7 +698,7 @@ accountName | The name, label, or id associating the owner of the account with t
 
 <a id="address"/>
 
-## 3.9 The "Address" Data Type
+## 3.8 The "Address" Data Type
 
 The JSON object used to (de)serialize the `http://gedcomx.org/v1/Address` data type is defined as follows:
 
@@ -762,7 +736,7 @@ street6 | The street (sixth line). | street6 | string
 }
 ```
 
-## 3.10 The "Conclusion" Data Type
+## 3.9 The "Conclusion" Data Type
 
 The JSON object used to (de)serialize the `http://gedcomx.org/v1/Conclusion` data type is defined as follows:
 
@@ -791,7 +765,7 @@ notes | A list of notes about this conclusion. | note | array of [`Note`](#note)
 }
 ```
 
-## 3.11 The "Gender" Data Type
+## 3.10 The "Gender" Data Type
 
 The JSON object used to (de)serialize the `http://gedcomx.org/v1/Gender` data type is defined as follows:
 
@@ -814,7 +788,7 @@ type | URI identifying the type of the gender. | type | [`URI`](#uri)
 
 <a id="name-conclusion"/>
 
-## 3.12 The "Name" Data Type
+## 3.11 The "Name" Data Type
 
 The JSON object used to (de)serialize the `http://gedcomx.org/v1/Name` data type is defined as follows:
 
@@ -843,7 +817,7 @@ nameForms | The name form(s) that best represents this name `NameForm` -- usuall
 
 <a id="fact-conclusion"/>
 
-## 3.13 The "Fact" Data Type
+## 3.12 The "Fact" Data Type
 
 The JSON object used to (de)serialize the `http://gedcomx.org/v1/Fact` data type is defined as follows:
 
@@ -874,7 +848,7 @@ qualifiers | Qualifiers to add additional details about the fact. | qualifiers |
 
 <a id="conclusion-event-role"/>
 
-## 3.14 The "EventRole" Data Type
+## 3.13 The "EventRole" Data Type
 
 The JSON object used to (de)serialize the `http://gedcomx.org/v1/EventRole`
 data type is defined as follows:
@@ -904,7 +878,7 @@ details | Details about the role of the person in the event. | details | string
 
 <a id="conclusion-date"/>
 
-## 3.15 The "Date" Data Type
+## 3.14 The "Date" Data Type
 
 The JSON object used to (de)serialize the `http://gedcomx.org/v1/Date` data type is defined as follows:
 
@@ -926,7 +900,7 @@ formal | The formal value of the date. | formal | [GEDCOM X Date](https://github
 
 <a id="conclusion-place-reference"/>
 
-# 3.16 The "PlaceReference" Data Type
+# 3.15 The "PlaceReference" Data Type
 
 the JSON object used to (de)serialize the `http://gedcomx.org/v1/PlaceReference` data type
 is defined as follows:
@@ -952,7 +926,7 @@ descriptionRef | A reference to a _description_ of this place. | description | [
 
 <a id="name-part"/>
 
-## 3.17 The "NamePart" Data Type
+## 3.16 The "NamePart" Data Type
 
 The JSON object used to (de)serialize the `http://gedcomx.org/v1/NamePart` data type is defined as follows:
 
@@ -977,7 +951,7 @@ qualifiers | Type qualifiers to further describe the type of the name part. | qu
 }
 ```
 
-## 3.18 The "NameForm" Data Type
+## 3.17 The "NameForm" Data Type
 
 The JSON object used to (de)serialize the `http://gedcomx.org/v1/NameForm` data type is defined as follows:
 
@@ -1003,7 +977,7 @@ parts | The parts of the name form. | parts | array of [`NamePart`](#name-part)
 ```
 <a id="qualifier"/>
 
-## 3.20 The "Qualifier" Data Type
+## 3.18 The "Qualifier" Data Type
 
 The JSON object used to (de)serialize the `http://gedcomx.org/v1/Qualifier` data type is defined as follows:
 

--- a/specifications/xml-format-specification.md
+++ b/specifications/xml-format-specification.md
@@ -638,45 +638,19 @@ name | description | XML property | XML type
 -----|-------------|--------------|---------
 lang | The locale identifier for the citation. | xml:lang (attribute) | [IETF BCP 47](http://tools.ietf.org/html/bcp47) locale tag
 value | A rendering of the full (working) citation as a string. | gx:value | xsd:string
-citationTemplate | The identifier of the citation template by which this citation may be interpreted. | gx:citationTemplate | [`gx:ResourceReference`](#resource-reference)
-fields | A list of citation fields about a source. | gx:field | [`gx:CitationField`](#citation-field)
 
 ### examples
 
 ```xml
   <... xml:lang="en">
     <gx:value>...a rendering of the full (working) citation as a string...</gx:value>
-    <gx:citationTemplate resource="http://identifier/for/ciation/template"/>
-    <gx:field>
-      ...
-    </gx:field>
     ...
   </...>
 ```
 
-<a id="citation-field"/>
-
-## 3.6 The "CitationField" Data Type
-
-The `gx:CitationField` XML type is used to (de)serialize the
-`http://gedcomx.org/v1/CitationField` data type.
-
-### properties
-
-name | description | XML property | XML type
------|-------------|--------------|---------
-name | The identifier for the citation detail -- defined by a citation template or a citation template library. | gx:name | [anyURI](#uri)
-value | A rendering of the full (working) citation as a string. | gx:value | xsd:string
-
-### examples
-
-```xml
-  <... name="...a citation field name...">...a citation field value...</...>
-```
-
 <a id="source-reference"/>
 
-## 3.7 The "SourceReference" Data Type
+## 3.6 The "SourceReference" Data Type
 
 The `gx:SourceReference` XML type is used to (de)serialized the `http://gedcomx.org/v1/SourceReference`
 data type.
@@ -703,7 +677,7 @@ attribution | The attribution of this source reference. | gx:attribution | [`gx:
 
 <a id="online-account"/>
 
-## 3.8 The "OnlineAccount" Data Type
+## 3.7 The "OnlineAccount" Data Type
 
 The `gx:OnlineAccount` XML type is used to (de)serialize the `http://gedcomx.org/v1/OnlineAccount`
 data type.
@@ -726,7 +700,7 @@ accountName | The name, label, or id associating the owner of the account with t
 
 <a id="address"/>
 
-## 3.9 The "Address" Data Type
+## 3.8 The "Address" Data Type
 
 The `gx:Address` XML type is used to (de)serialize the `http://gedcomx.org/v1/Address`
 data type.
@@ -765,7 +739,7 @@ street6 | The street (sixth line). | gx:street6 | xsd:string
   </...>
 ```
 
-## 3.10 The "Conclusion" Data Type
+## 3.9 The "Conclusion" Data Type
 
 The `gx:Conclusion` XML type is used to (de)serialize the `http://gedcomx.org/v1/Conclusion`
 data type.
@@ -801,7 +775,7 @@ notes | A list of notes about this conclusion. | gx:note | [`gx:Note`](#note)
 
 <a id="gender-conclusion"/>
 
-## 3.11 The "Gender" Data Type
+## 3.10 The "Gender" Data Type
 
 The `gx:Gender` XML type is used to (de)serialize the `http://gedcomx.org/v1/Gender`
 data type.
@@ -824,7 +798,7 @@ type | The gender type. | type (attribute) | [`URI`](#uri)
 
 <a id="name-conclusion"/>
 
-## 3.12 The "Name" Data Type
+## 3.11 The "Name" Data Type
 
 The `gx:Name` XML type is used to (de)serialize the `http://gedcomx.org/v1/Name`
 data type.
@@ -858,7 +832,7 @@ nameForms | The name form(s) that best represents this name `NameForm` -- usuall
 
 <a id="fact-conclusion"/>
 
-## 3.13 The "Fact" Data Type
+## 3.12 The "Fact" Data Type
 
 The `gx:Fact` XML type is used to (de)serialize the `http://gedcomx.org/v1/Fact`
 data type.
@@ -897,7 +871,7 @@ qualifiers | Qualifiers to add additional details about the fact. | gx:qualifier
 
 <a id="conclusion-event-role"/>
 
-## 3.14 The "EventRole" Data Type
+## 3.13 The "EventRole" Data Type
 
 The `gx:EventRole` XML type is used to (de)serialize the `http://gedcomx.org/v1/EventRole`
 data type.
@@ -924,7 +898,7 @@ details | Details about the role of the person in the event. | gx:details | xs:s
 
 <a id="conclusion-date"/>
 
-## 3.15 The "Date" Data Type
+## 3.14 The "Date" Data Type
 
 The `gx:Date` XML type is used to (de)serialize the `http://gedcomx.org/v1/Date`
 data type.
@@ -947,7 +921,7 @@ formal | The formal value of the date. | gx:formal | [GEDCOM X Date](https://git
 
 <a id="conclusion-place-reference"/>
 
-## 3.16 The "PlaceReference" Data Type
+## 3.15 The "PlaceReference" Data Type
 
 The `gx:PlaceDescription` is used to (de)serialize the `http://gedcomx.org/v1/PlaceReference` data type.
 
@@ -972,7 +946,7 @@ descriptionRef | A reference to a _description_ of this place. | description (at
 
 <a id="name-part"/>
 
-## 3.17 The "NamePart" Data Type
+## 3.16 The "NamePart" Data Type
 
 The `gx:NamePart` XML type is used to (de)serialize the `http://gedcomx.org/v1/NamePart`
 data type.
@@ -999,7 +973,7 @@ qualifiers | Qualifiers to add additional semantic meaning to the name part. | g
 
  <a id="name-form"/>
 
-## 3.18 The "NameForm" Data Type
+## 3.17 The "NameForm" Data Type
 
 The `NameForm` XML type is used to (de)serialize the `http://gedcomx.org/v1/NameForm`
 data type.
@@ -1030,7 +1004,7 @@ parts | Any identified name parts from the name represented in this instance, or
 
 <a id="qualifier"/>
 
-## 3.20 The "Qualifier" Data Type
+## 3.18 The "Qualifier" Data Type
 
 The `Qualifier` XML type is used to (de)serialize the `http://gedcomx.org/v1/Qualifier`
 data type.


### PR DESCRIPTION
We have add citation template requirements to section 3.5.1.  As part of this change, we have removed section 3.8 -- the former placeholder for citation templates.  We currently believe that the definition of 'CitationTemplate' data type will happen outside the scope of the first version of this specification.

We invite your comments.
