### PR TITLE
Add textType to the Document class.

### DIFF
--- a/specifications/conceptual-model-specification.md
+++ b/specifications/conceptual-model-specification.md
@@ -412,12 +412,12 @@ The "xhtml" text type identifies XHTML documents complying with the
 minimize security risks, support for the following subset of modules (defined by XHTML Modularization 
 1.1 W3C Recommendation](http://www.w3.org/TR/xhtml-modularization/)) is REQUIRED:
 
-* [Core Modules](http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#sec_5.2.)
-* [Text Extension Modules](http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_text)
-* [Table Modules](http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#sec_5.6.)
+* [Core Modules](http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#sec_5.2.), including the Structure Module, Text Module, Hypertext Module, and List Module.
+* [Text Extension Modules](http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_text), including the Presentation Module, Edit Module, and Bi-directional Text Module.
+* [Table Modules](http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#sec_5.6.), including the Basic Tables Module, and Tables Module.
 * [Base Module](http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_basemodule)
 
-Support for other XHTML modules is OPTIONAL. Parsers may ignore elements from optional modules.
+Support for other XHTML modules is OPTIONAL. Parsers MAY ignore elements from optional modules.
 
 <a id="conclusion-place"/>
 


### PR DESCRIPTION
##### Requirements

GEDCOM X needs to more fully support the transmission of a proof argument.  The current model supports only a plain text `Document`, or a reference to an artifact that contains the proof argument — via a `SourceDescription`.  A plain text document lacks the functionality typically required to express a complex proof.  These narratives usually require sophisticated text layouts (tables, lists, links, text styling), often include images, and also require mechanisms to integrate source documentation into the narrative (e.g., footnotes, endnotes or another equivalent documentation mechanism).

From a data exchange point of view, we would like the GEDCOM X model to be capable of transmitting the “raw” materials required to express a sophisticated proof argument, but leave the rendering decisions to the applications that consume this data.

In our opinion, a proof argument narrative belongs in a GEDCOM X `Document` object.  We can already associate sources with a `Document`.  But a `Document` lacks features for text layout, images and documentation.
##### Interim Proposal

As a step toward a solution to some of these issues, we are proposing the addition of a `Document` **_text type_**. Initially, we are proposing two possible text types: “plain” or “xhtml”.  Adding XHTML as a text type would allow a rich layout capability, and would allow the inclusion of images.  We expect that such a design can be expanded such that statements in the narrative can be associated with `Document.sources` by embedding microdata in the XHTML (see schema.org).

This is an interim proposal in that the proposal does not addressing the source documentation requirements (i.e., it does not included any definition around microdata data and its use in the XHTML).
