### PR TITLE
GEDCOM X and support for multiple languages for names, places, dates?

### DIFF
--- a/specifications/fact-types-specification.md
+++ b/specifications/fact-types-specification.md
@@ -87,6 +87,7 @@ URI | description
 `http://gedcomx.org/Excommunication`| A fact of a person's excommunication from a church.
 `http://gedcomx.org/FirstCommunion`| A fact of a person's first communion in a church.
 `http://gedcomx.org/Funeral`| A fact of a person's funeral.
+`http://gedcomx.org/Heimat`| A fact of a person's _heimat_. "Heimat" refers to a person's affiliation by birth to a specific geographic place. Distinct heimaten are often useful as indicators that two persons of the same name are not likely to be closely related genealogically. In English, "heimat" may be described using terms like "ancestral home", "homeland", or "place of origin".
 `http://gedcomx.org/Immigration`| A fact of a person's immigration.
 `http://gedcomx.org/Imprisonment`| A fact of a person's imprisonment.
 `http://gedcomx.org/LandTransation`| A fact of a land transaction enacted by a person.


### PR DESCRIPTION
Hello!

I am working on an improved solution for cooperating in the genealogy research with relatives in various countries (mainly Sweden, Finland, USA, Canada and Russia). I am confronted with the folowing problems:

Example 1: Several places have names in multiple languages. 
I have relatives in Petrozavodsk in Russia. There are many alternative names to use to identify the same place:
Petrozavodsk (english and some other languages)
Петрозаво́дск (russian)
Petroskoi (finnish and karelian (very small local language) as it used to be a part of Finland until WW II)
Petroskoj (swedish as it used to be a swedish city until lost to Russia)
Onegaborg (alternate historical swedish name)

Example 2: Several persons have names in some research in one language and in other persons databases all names are listed with different language versions. 
Sweden ruled over Finland until 1809 and the swedish church started to document all birhts, marriages and deaths and wrote the names down in swedish language. Nowadays finnish genealogists have more and more tended to modify the data into finnish language variants. This makes it extremely hard to find duplicate names as a name such as "Juho Antinpoika Torppa" (finnish language version) can in fact be the same person as someone called "Johan Andersson Torp" with the swedish spelling. For names in languages with other alphabets, it is absolutely crucial to also use language variants to at all be able to match the people (for "Александр" (russian) it is crucial to use "Alexander" as alternative for those who can't even read russian. In some questions, it may make also sense to use this kind of translation for persons moving to the USA or Canada. At Ellis Island many names were changed into US suitable versions, sometimes with quite simple translation rules, some names (particularly finnish names) were replaced by completely different more easily pronuinciable names. When for example the great grandfather of Pamela Anderson moved to Canada from western Finland, the name was changed from Hyytiäinen to Anderson (which is not exactly a translation, but simply a name change for which there is anyhow already a solution).

Example 3:Middle names in multiple languages.
Sweden and Finland often especially in the past used middle names which identified the name of the father.
Antinpoika means that the person is the son of a father named Antti (finnish)
Antintytär menas that the person is the daughter of a father named Antti (finnish)
Andersson means that the person is the son of a father named Anders (swedish)
Andersdotter means that the person is the daughter of a father named Anders (swedish)
The problem is that Antti and Anders can be the same person and sometimes middle names are used and sometimes not. This makes it even harder to find matching persons as "Johan Andersson Torp" can sometimes be listed as "Juho Torppa" and still be the same person...

Example 4: Date notation in multiple languages.
If I collect data from various sources I have often the problem that the date information isn't always stored in the same format. With swedish information about month, you write for example "maj" instead of "May" and some geneological software has failed to detect the language differences. If you gather GEDCOM 5.5 files from various persons in different countries you end up having a mess trying to merge if the dates are in different languages. I have files in Swedish, Finnish, English, German and Russian. 

I hope GEDCOM X will provide support to deal with all of the above mentioned examples, but how?

I am right now building a database into which I compile all the information from multiple GEDCOMS and I will solve all of the above mentioned problems, but what I want to know is how this will work in GEDCOM X, so that I will also be able to export into that format once the standard gets properly established.

Best regards,
Björn Pellkvist
