### PR TITLE
explicit "information as evidence" concept

### DIFF
--- a/specifications/conceptual-model-specification.md
+++ b/specifications/conceptual-model-specification.md
@@ -655,8 +655,8 @@ The identifier for the "EvidenceReference" data type is:
 
 name  | description | data type | constraints
 ------|-------------|-----------|------------
-resource  | Reference to data being used as evidence. | [URI](#uri) | REQUIRED. MUST resolve to an instance of conclusion [`http://gedcomx.org/v1/Conclusion`](#311-the-conclusion-data-type).
-analysis  | Reference to a document containing analysis that supports the use of the referenced data as evidence. | [URI](#uri) | OPTIONAL. If provided, MUST resolve to an instance of [`http://gedcomx.org/v1/Document`](#26-the-document-data-type) of type `http://gedcomx.org/Analysis`.
+resource  | Reference to data being used as _evidence_. | [URI](#uri) | REQUIRED. MUST resolve to an instance of conclusion [`http://gedcomx.org/v1/Conclusion`](#311-the-conclusion-data-type).
+analysis  | Reference to a document containing analysis that supports the use of the referenced data as _evidence_. | [URI](#uri) | OPTIONAL. If provided, MUST resolve to an instance of [`http://gedcomx.org/v1/Document`](#26-the-document-data-type) of type `http://gedcomx.org/Analysis`.
 attribution | The attribution of this source reference. | [`http://gedcomx.org/Attribution`](#attribution) | OPTIONAL. If not provided, the attribution of the containing resource of the source reference is assumed.
 
 ### examples

--- a/specifications/json-format-specification.md
+++ b/specifications/json-format-specification.md
@@ -678,9 +678,39 @@ attribution | The attribution of this source reference. | attribution | [`Attrib
 }
 ```
 
+
+<a id="evidence-reference"/>
+
+## 3.7 The "EvidenceReference" Data Type
+
+The JSON object used to (de)serialize the `http://gedcomx.org/v1/EvidenceReference`
+data type is defined as follows:
+
+### properties
+
+name | description | JSON member | JSON object type
+-----|-------------|--------------|---------
+resource  | Reference to data being used as _evidence_. | resource | [`URI`](#uri)
+analysis  | Reference to a document containing analysis that supports the use of the referenced data as _evidence_. | resource | [`URI`](#uri)
+attribution | The attribution of this _evidence_ reference. | attribution | [`Attribution`](#attribution)
+
+### examples
+
+```json
+{
+  "resource" : "http://identifier/for/data/being/referenced",
+  "analysis" : "http://identifier/for/analysis/document",
+  "attribution" : { ... }
+
+  ...possibility of extension elements...
+
+}
+```
+
+
 <a id="online-account"/>
 
-## 3.7 The "OnlineAccount" Data Type
+## 3.8 The "OnlineAccount" Data Type
 
 The JSON object used to (de)serialize the `http://gedcomx.org/v1/OnlineAccount` data type is defined as follows:
 
@@ -704,7 +734,7 @@ accountName | The name, label, or id associating the owner of the account with t
 
 <a id="address"/>
 
-## 3.8 The "Address" Data Type
+## 3.9 The "Address" Data Type
 
 The JSON object used to (de)serialize the `http://gedcomx.org/v1/Address` data type is defined as follows:
 
@@ -742,7 +772,7 @@ street6 | The street (sixth line). | street6 | string
 }
 ```
 
-## 3.9 The "Conclusion" Data Type
+## 3.10 The "Conclusion" Data Type
 
 The JSON object used to (de)serialize the `http://gedcomx.org/v1/Conclusion` data type is defined as follows:
 
@@ -771,7 +801,7 @@ notes | A list of notes about this conclusion. | note | array of [`Note`](#note)
 }
 ```
 
-## 3.10 The "Gender" Data Type
+## 3.11 The "Gender" Data Type
 
 The JSON object used to (de)serialize the `http://gedcomx.org/v1/Gender` data type is defined as follows:
 
@@ -794,7 +824,7 @@ type | URI identifying the type of the gender. | type | [`URI`](#uri)
 
 <a id="name-conclusion"/>
 
-## 3.11 The "Name" Data Type
+## 3.12 The "Name" Data Type
 
 The JSON object used to (de)serialize the `http://gedcomx.org/v1/Name` data type is defined as follows:
 
@@ -823,7 +853,7 @@ nameForms | The name form(s) that best represents this name `NameForm` -- usuall
 
 <a id="fact-conclusion"/>
 
-## 3.12 The "Fact" Data Type
+## 3.13 The "Fact" Data Type
 
 The JSON object used to (de)serialize the `http://gedcomx.org/v1/Fact` data type is defined as follows:
 
@@ -854,7 +884,7 @@ qualifiers | Qualifiers to add additional details about the fact. | qualifiers |
 
 <a id="conclusion-event-role"/>
 
-## 3.13 The "EventRole" Data Type
+## 3.14 The "EventRole" Data Type
 
 The JSON object used to (de)serialize the `http://gedcomx.org/v1/EventRole`
 data type is defined as follows:
@@ -884,7 +914,7 @@ details | Details about the role of the person in the event. | details | string
 
 <a id="conclusion-date"/>
 
-## 3.14 The "Date" Data Type
+## 3.15 The "Date" Data Type
 
 The JSON object used to (de)serialize the `http://gedcomx.org/v1/Date` data type is defined as follows:
 
@@ -906,7 +936,7 @@ formal | The formal value of the date. | formal | [GEDCOM X Date](https://github
 
 <a id="conclusion-place-reference"/>
 
-# 3.15 The "PlaceReference" Data Type
+# 3.16 The "PlaceReference" Data Type
 
 the JSON object used to (de)serialize the `http://gedcomx.org/v1/PlaceReference` data type
 is defined as follows:
@@ -932,7 +962,7 @@ descriptionRef | A reference to a _description_ of this place. | description | [
 
 <a id="name-part"/>
 
-## 3.16 The "NamePart" Data Type
+## 3.17 The "NamePart" Data Type
 
 The JSON object used to (de)serialize the `http://gedcomx.org/v1/NamePart` data type is defined as follows:
 
@@ -957,7 +987,7 @@ qualifiers | Type qualifiers to further describe the type of the name part. | qu
 }
 ```
 
-## 3.17 The "NameForm" Data Type
+## 3.18 The "NameForm" Data Type
 
 The JSON object used to (de)serialize the `http://gedcomx.org/v1/NameForm` data type is defined as follows:
 
@@ -983,7 +1013,7 @@ parts | The parts of the name form. | parts | array of [`NamePart`](#name-part)
 ```
 <a id="qualifier"/>
 
-## 3.18 The "Qualifier" Data Type
+## 3.19 The "Qualifier" Data Type
 
 The JSON object used to (de)serialize the `http://gedcomx.org/v1/Qualifier` data type is defined as follows:
 

--- a/specifications/xml-format-specification.md
+++ b/specifications/xml-format-specification.md
@@ -676,9 +676,38 @@ attribution | The attribution of this source reference. | gx:attribution | [`gx:
   </...>
 ```
 
+<a id="evidence-reference"/>
+
+## 3.7 The "EvidenceReference" Data Type
+
+The `gx:EvidenceReference` XML type is used to (de)serialized the `http://gedcomx.org/v1/EvidenceReference`
+data type.
+
+### properties
+
+name | description | XML property | XML type
+-----|-------------|--------------|---------
+resource  | Reference to data being used as _evidence_. | description (attribute) | [`URI`](#uri)
+analysis  | Reference to a document containing analysis that supports the use of the referenced data as _evidence_. | gx:analysis | [`URI`](#uri)
+attribution | The attribution of this _evidence_ reference. | gx:attribution | [`gx:Attribution`](#attribution)
+
+### examples
+
+```xml
+  <... resource="http://identifier/for/data/being/referenced">
+    <gx:analysis resource="http://identifier/for/analysis/document"/>
+    <gx:attribution>
+      ...
+    </gx:attribution>
+
+    <!-- possibility of extension elements -->
+
+  </...>
+```
+
 <a id="online-account"/>
 
-## 3.7 The "OnlineAccount" Data Type
+## 3.8 The "OnlineAccount" Data Type
 
 The `gx:OnlineAccount` XML type is used to (de)serialize the `http://gedcomx.org/v1/OnlineAccount`
 data type.
@@ -701,7 +730,7 @@ accountName | The name, label, or id associating the owner of the account with t
 
 <a id="address"/>
 
-## 3.8 The "Address" Data Type
+## 3.9 The "Address" Data Type
 
 The `gx:Address` XML type is used to (de)serialize the `http://gedcomx.org/v1/Address`
 data type.
@@ -740,7 +769,7 @@ street6 | The street (sixth line). | gx:street6 | xsd:string
   </...>
 ```
 
-## 3.9 The "Conclusion" Data Type
+## 3.10 The "Conclusion" Data Type
 
 The `gx:Conclusion` XML type is used to (de)serialize the `http://gedcomx.org/v1/Conclusion`
 data type.
@@ -776,7 +805,7 @@ notes | A list of notes about this conclusion. | gx:note | [`gx:Note`](#note)
 
 <a id="gender-conclusion"/>
 
-## 3.10 The "Gender" Data Type
+## 3.11 The "Gender" Data Type
 
 The `gx:Gender` XML type is used to (de)serialize the `http://gedcomx.org/v1/Gender`
 data type.
@@ -799,7 +828,7 @@ type | The gender type. | type (attribute) | [`URI`](#uri)
 
 <a id="name-conclusion"/>
 
-## 3.11 The "Name" Data Type
+## 3.12 The "Name" Data Type
 
 The `gx:Name` XML type is used to (de)serialize the `http://gedcomx.org/v1/Name`
 data type.
@@ -833,7 +862,7 @@ nameForms | The name form(s) that best represents this name `NameForm` -- usuall
 
 <a id="fact-conclusion"/>
 
-## 3.12 The "Fact" Data Type
+## 3.13 The "Fact" Data Type
 
 The `gx:Fact` XML type is used to (de)serialize the `http://gedcomx.org/v1/Fact`
 data type.
@@ -872,7 +901,7 @@ qualifiers | Qualifiers to add additional details about the fact. | gx:qualifier
 
 <a id="conclusion-event-role"/>
 
-## 3.13 The "EventRole" Data Type
+## 3.14 The "EventRole" Data Type
 
 The `gx:EventRole` XML type is used to (de)serialize the `http://gedcomx.org/v1/EventRole`
 data type.
@@ -899,7 +928,7 @@ details | Details about the role of the person in the event. | gx:details | xs:s
 
 <a id="conclusion-date"/>
 
-## 3.14 The "Date" Data Type
+## 3.15 The "Date" Data Type
 
 The `gx:Date` XML type is used to (de)serialize the `http://gedcomx.org/v1/Date`
 data type.
@@ -922,7 +951,7 @@ formal | The formal value of the date. | gx:formal | [GEDCOM X Date](https://git
 
 <a id="conclusion-place-reference"/>
 
-## 3.15 The "PlaceReference" Data Type
+## 3.16 The "PlaceReference" Data Type
 
 The `gx:PlaceDescription` is used to (de)serialize the `http://gedcomx.org/v1/PlaceReference` data type.
 
@@ -947,7 +976,7 @@ descriptionRef | A reference to a _description_ of this place. | description (at
 
 <a id="name-part"/>
 
-## 3.16 The "NamePart" Data Type
+## 3.17 The "NamePart" Data Type
 
 The `gx:NamePart` XML type is used to (de)serialize the `http://gedcomx.org/v1/NamePart`
 data type.
@@ -974,7 +1003,7 @@ qualifiers | Qualifiers to add additional semantic meaning to the name part. | g
 
  <a id="name-form"/>
 
-## 3.17 The "NameForm" Data Type
+## 3.18 The "NameForm" Data Type
 
 The `NameForm` XML type is used to (de)serialize the `http://gedcomx.org/v1/NameForm`
 data type.
@@ -1005,7 +1034,7 @@ parts | Any identified name parts from the name represented in this instance, or
 
 <a id="qualifier"/>
 
-## 3.18 The "Qualifier" Data Type
+## 3.19 The "Qualifier" Data Type
 
 The `Qualifier` XML type is used to (de)serialize the `http://gedcomx.org/v1/Qualifier`
 data type.


### PR DESCRIPTION
#### Definitions

From the Genealogical Proof Standard, this proposal assumes the following definitions:
- _Source_ &mdash; an _Information_ container
- _Information_ &mdash; data extracted of the _Source_
- _Evidence_ &mdash; _Information_ selected and used to answer a _Question_

In graphical form:
![InformationAsEvidenceDomainConcepts](https://f.cloud.github.com/assets/840078/392605/26b35c66-a782-11e2-9580-2b3dcae4d5d9.png)
#### In the GEDCOM X Model

_Sources_ are described with instances of `SourceDescription`.

_Information_ can be modeled with instances of `Conclusion` that have `extracted` set to “true”.

We do not explicitly model genealogical _Questions_ in GEDCOM X.  Instead, the model allows _Answers_ to be captured in instances of `Conclusion`.  The `Conclusion` _type_ is maybe the best hint as to what _Question_ was being answered.

In the GEDCOM X model, the mechanism for relating **_information_** with a **_question/answer_** is an instance of `Identifier` with its `type` set as `http://gedcomx.org/Evidence`.
#### Proposal

We would like concept of **_evidence_** to be more explicit in the GEDCOM X model&mdash;to make the association between **_information_** and its **_question/answer_** its own extensible entity.  We are, therefore, submitting for your review, a proposal to add an `EvidenceReference` entity.

`EvidenceReference` has the following members:
- `resource` &mdash; the representation of _information_
- `attribution` &mdash; attribution for the reference

We propose that an `evidence` member be added to the following top-level specializations of `Conclusion`:
- Person
- Relationship
- Event
- PlaceDescription
