### PR TITLE
representing "negative evidence"

### DIFF
--- a/specifications/conceptual-model-specification.md
+++ b/specifications/conceptual-model-specification.md
@@ -670,8 +670,8 @@ The identifier for the "EvidenceReference" data type is:
 
 name  | description | data type | constraints
 ------|-------------|-----------|------------
-resource  | Reference to data being used as _evidence_. | [URI](#uri) | REQUIRED. MUST resolve to an instance of [`http://gedcomx.org/v1/Subject`](#subject).
-analysis  | Reference to a document containing analysis that supports the use of the referenced data as _evidence_. | [URI](#uri) | OPTIONAL. If provided, MUST resolve to an instance of [`http://gedcomx.org/v1/Document`](#26-the-document-data-type) of type `http://gedcomx.org/Analysis`.
+resource  | Reference to data being used as _evidence_. | [URI](#uri) | REQUIRED, except when modeling "negative evidence", in which case it MUST NOT be present. If provided, MUST resolve to an instance of [`http://gedcomx.org/v1/Subject`](#subject).
+analysis  | Reference to a document containing analysis that supports the use of the referenced data as _evidence_. | [URI](#uri) | OPTIONAL, except when modeling "negative evidence", in which case it MUST be present. If provided, MUST resolve to an instance of [`http://gedcomx.org/v1/Document`](#26-the-document-data-type) of type `http://gedcomx.org/Analysis`.
 attribution | The attribution of this source reference. | [`http://gedcomx.org/Attribution`](#attribution) | OPTIONAL. If not provided, the attribution of the containing resource of the source reference is assumed.
 
 ### examples


### PR DESCRIPTION
Representing "negative evidence" or "the absence of evidence one would expect to find" is often important in forming a proof argument. We want the GEDCOM X model to support this concept.
#### Requirements

Documenting negative evidence typically requires the following elements:
- a citation(s) for the body of records searched
- a description of the search (methods, search terms, scope, party conducting the search, date of the search, etc.)

From a modeling perspective, we would like "negative evidence" to look like and use the same mechanisms used to represent "evidence".
#### Proposal

We think that the documentation requirements can be met with a `Document` object. The `text` of the document could be used to described the search—the date of the search, who conducted the search, how the search was carried out, search terms, etc. The `sources` list could contain the source description(s) for the body of records that was searched.

Assuming `Document` as the documentation mechanism for a negative search, how should we associate this `Document` with our hypothesis as "negative evidence" supporting our hypothesis?

In the GEDCOM X model, we use `EvidenceReference` to associate data with a hypothesis as _evidence_.  The `resource` member points to the data being used as _evidence_ and is a required field.  But in the case of "negative evidence", there is no data to point to&mdash;by definition, we have an "absence of data".  It is by _analysis_ that we have determined that there was no data where there ought to have been some.

We would like to propose that we can represent "negative evidence" with an `EvidenceReference` instance with the document describing the negative search as the `analysis` document, and an explicitly missing `resource` reference.

However, as currently defined, an `EvidenceReference` REQUIRES a `resource` reference (explicitly present) and that reference MUST resolve to an object that matches the type of its container (a specialization of `Subject`).  This means that the current constraint would not allow `resource` to be explicitly missing.  Therefore, we would like to modify the constraint to something like the following.

For `resource`:

REQUIRED, except when modeling "negative evidence", in which case it MUST NOT be present.  If provided, MUST resolve to an instance of [`http://gedcomx.org/v1/Subject`].

For `analysis`:

OPTIONAL, except when modeling "negative evidence", in which case it MUST be present.  If provided, MUST resolve to an instance of [`http://gedcomx.org/v1/Document`] of type `http://gedcomx.org/Analysis`

The above changes are include in this pull request.
