### PR TITLE
Spec lacks details of extensibility and use of vocabularies

### DIFF
--- a/specifications/conceptual-model-specification.md
+++ b/specifications/conceptual-model-specification.md
@@ -1233,6 +1233,7 @@ Data in a conclusion that is identified as "extracted" MUST conform to the follo
 GEDCOM X provides a specific definition for the term "persona" that is used to refer to an instance of
 `http://gedcomx.org/v1/Person` that has been identified as an extracted conclusion.
 
+<a name="extensibility"/>
 
 # 5. Extensibility
 

--- a/specifications/json-format-specification.md
+++ b/specifications/json-format-specification.md
@@ -1160,15 +1160,28 @@ The following is an example of the structure of a GEDCOM X XML Element:
 ```
 
 
-# 6. Known JSON Extension Members
+# 6. Extensibility
 
-GEDCOM X defines the notion of extension properties, and the JSON serialization
-supports the extensibility requirements detailed in the GEDCOM X conceptual model
-specification. When an extension property is provided in a JSON object, the type
-of the object can be determined by the name of the JSON member.
+In accordance with the [extensibility provisions](https://github.com/FamilySearch/gedcomx/blob/master/specifications/conceptual-model-specification.md#extensibility)
+of the GEDCOM X Conceptual Model, extensions MAY be provided as JSON members on data types where extensions are not
+explicitly prohibited.
 
-For convenience, GEDCOM X reserves the use of the following member names as
-"known" extension members:
+## 6.1 Data Type Extensions
+
+New data types MAY be defined as extensions to the GEDCOM X XML Serialization Format by providing the following:
+
+* A conceptual data type definition as specified by the GEDCOM X Conceptual Model Section 5.1.
+* A JSON member name for each property of the data type.
+
+Specifications that define new data types as GEDCOM X JSON extensions MUST be published and made freely available and
+compatible with the terms and constraints that govern the GEDCOM X JSON Serialization Format.
+
+## 6.2 Known JSON Extension Members
+
+GEDCOM X defines a set of JSON members that are explicitly associated with a data type such that
+GEDCOM X JSON parsers MAY interpret the members correctly if they are included as an extension
+member in a valid data type as defined by the conceptual model. The following members are
+identified:
 
 name | JSON object type
 -----|-----------------
@@ -1179,7 +1192,8 @@ facts | array of [`Fact`](#fact-conclusion)
 names | array of [`Name`](#name-conclusion)
 genders | array of [`Gender`](#gender-conclusion)
 sourceReferences | array of [`SourceReference`](#source-reference)
-sourceDescriptions | array of [`SourceDescription`](#rdf-description)
+sourceDescriptions | array of [`SourceDescription`](#source-description)
+placeDescriptions | array of [`PlaceDescription`](#place-description)
 agents | array of [`Agent`](#agent)
 documents | array of [`Document`](#document)
 attribution | array of [`Attribution`](#attribution)

--- a/specifications/xml-format-specification.md
+++ b/specifications/xml-format-specification.md
@@ -1201,7 +1201,27 @@ The following is an example of the structure of a GEDCOM X XML Element:
 ```
 
 
-# 6. XML Extension Elements
+# 6. Extensibility
+
+In accordance with the [extensibility provisions](https://github.com/FamilySearch/gedcomx/blob/master/specifications/conceptual-model-specification.md#extensibility)
+of the GEDCOM X Conceptual Model, extensions MAY be provided as XML elements or attributes on data types where
+extensions are not explicitly prohibited.
+
+## 6.1 Data Type Extensions
+
+New data types MAY be defined as extensions to the GEDCOM X XML Serialization Format by providing the following:
+
+* A conceptual data type definition as specified by the GEDCOM X Conceptual Model Section 5.1.
+* An XML name and namespace for each property of the data type, and whether the property is serialized as an XML element or attribute.
+
+The namespace `http://gedcomx.org/v1/` is reserved for elements and attributes defined by the GEDCOM X specification
+set. Data types defined outside the scope of the GEDCOM X specification set MUST NOT use the value `http://gedcomx.org/v1/`
+as a namespace for the XML element or attribute.
+
+Specifications that define new data types as GEDCOM X XML extensions MUST be published and made freely available and
+compatible with the terms and constraints that govern the GEDCOM X XML Serialization Format.
+
+## 6.2 Known XML Element Extensions
 
 GEDCOM X defines a set of elements that are explicitly associated with a data type such that
 GEDCOM X XML parsers MAY interpret the elements correctly if they are included as an extension
@@ -1218,6 +1238,7 @@ gx:gender | [`gx:Gender`](#gender-conclusion)
 gx:agent| [`gx:Agent`](#agent)
 gx:sourceReference | [`gx:SourceReference`](#source-reference)
 gx:sourceDescription | [`gx:SourceDescription`](#source-description)
+gx:placeDescription | [`gx:PlaceDescription`](#place-description)
 gx:event | [`gx:Event`](#event)
 gx:document | [`gx:Document`](#document)
 gx:attribution | [`gx:Attribution`](#attribution)


### PR DESCRIPTION
This issue arises from the discussions in #185 and #187, and replaces the latter.

[Section 8: Extensibilty](https://github.com/FamilySearch/gedcomx/blob/master/specifications/conceptual-model-specification.md#8-extensibility) describes the term "foreign vocabularies" (any "unrecognized" data type or property) and attempts to describe how they may be used.

It doesn't succeed. It's confusing and too permissive -- the sorry history of GEDCOM shows that vendors will use extension features to make their exported GEDCOM files unintelligible to other programs as a way to lock-in users.

As a starting point:
- Provide a formal definition for "vocabulary"
- Specify (or reference specifications which specify) how a vocabulary must be defined and require that vocabularies must be published and freely licensed under the same terms as GedcomX.
- Clarify the usage. For example, "GEDCOM X allows properties of foreign vocabularies in any data type, except where it is explicitly forbidden." might mean "Any property of any GEDCOMX data type may contain a URI from a foreign vocabulary unless the property is explicitly limited to a particular vocabulary." or it might mean something else.
- The term "controlled vocabulary" is used in #187 without explaining what "controlled" means. Define it in the spec.  
