### PR TITLE
proposal: new properties on SourceDescription

### DIFF
--- a/specifications/conceptual-model-specification.md
+++ b/specifications/conceptual-model-specification.md
@@ -328,6 +328,13 @@ componentOf | A reference to the source that contains this source, i.e. its pare
 titles | The display name(s) for this source. | List of [`http://gedcomx.org/TextValue`](#text-value). Order is preserved. | OPTIONAL. If more than one title is provided, titles are assumed to be given in order of preference, with the most preferred title in the first position in the list.
 notes  | A list of notes about a source. | List of [`http://gedcomx.org/Note`](#note) | OPTIONAL.
 attribution | The attribution of this source description. | [`http://gedcomx.org/Attribution`](#attribution) | OPTIONAL. If not provided, the attribution of the containing data set (e.g. file) of the source description is assumed.
+rights  | The rights for this resource. | List of [URI](#uri). Order is preserved. | OPTIONAL. If provided, MUST resolve to a resource that describes the rights associated with the resource being described.
+coverage | The coverage of the resource. | [`http://gedcomx.org/v1/Coverage`](#coverage) | OPTIONAL.
+descriptions | Human-readable descriptions of this source. | List of [`http://gedcomx.org/TextValue`](#text-value). Order is preserved. | OPTIONAL. If more than one description is provided, descriptions are assumed to be given in order of preference, with the most preferred description in the first position in the list.
+identifiers | A list of identifiers for the resource being described. | List of [`http://gedcomx.org/v1/Identifier`](#identifier-type). Order is preserved. | OPTIONAL.
+created | Timestamp of when the resource being described was created. | timestamp | OPTIONAL.
+modified | Timestamp of when the resource being described was modified. | timestamp | OPTIONAL.
+repository | A reference to the repository that contains the described resource. | [URI](#uri) | OPTIONAL. If provided, MUST resolve to an instance of [`http://gedcomx.org/v1/Agent`](#agent).
 
 <a name="known-resource-types"/>
 
@@ -1250,6 +1257,25 @@ name  | description | data type | constraints
 ------|-------------|-----------|------------
 name | The name of the qualifier. | [Enumerated Value](#enumerated-value) | REQUIRED. It is RECOMMENDED that the qualifier name resolve to an element of a constrained vocabulary.
 value | The value of the qualifier. | string | OPTIONAL. If provided, the name MAY give the semantic meaning of the value.
+
+<a name="coverage"/>
+
+## 3.21 The "Coverage" Data Type
+
+The `Coverage` data type defines the data structure used to supply information about the coverage of a resource.
+
+### identifier
+
+The identifier for the "Coverage" data type is:
+
+`http://gedcomx.org/v1/Coverage`
+
+### properties
+
+name  | description | data type | constraints
+------|-------------|-----------|------------
+spatial | The spatial (i.e., geographic) coverage. | [`http://gedcomx.org/v1/PlaceReference`](#conclusion-place-reference) | OPTIONAL.
+temporal | The temporal coverage. | [`http://gedcomx.org/v1/Date`](#conclusion-date) | OPTIONAL.
 
 
 <a name="extracted-conclusion-constraints"/>

--- a/specifications/json-format-specification.md
+++ b/specifications/json-format-specification.md
@@ -328,6 +328,13 @@ componentOf | A reference to the source that contains this source. | componentOf
 titles | The display name(s) for this source. | titles | array of [`TextValue`](#text-value)
 notes | A list of notes about a source | notes | array of [`Note`](#note)
 attribution | The attribution of this source. | attribution | [`Attribution`](#attribution)
+rights  | The rights for this resource. | rights | array of [`ResourceReference`](#resource-reference)
+coverage | The coverage of the resource. | coverage | [`Coverage`](#coverage)
+descriptions | Human-readable descriptions of this source. | descriptions | array of [`TextValue`](#text-value)
+identifiers | A list of identifiers for the resource being described. | identifiers | array of [`Identifier`](#identifier-type)
+created | Timestamp of when the resource being described was created. | created | number (milliseconds since epoch)
+modified | Timestamp of when the resource being described was modified. | modified | number (milliseconds since epoch)
+repository | A reference to the repository that contains the described resource. | repository | [`ResourceReference`](#resource-reference)
 
 ### examples
 
@@ -348,7 +355,14 @@ attribution | The attribution of this source. | attribution | [`Attribution`](#a
   "componentOf" : { ... },
   "titles" : [ { ... }, { ... } ],
   "notes" : [ { ... }, { ... } ],
-  "attribution" : { ... }
+  "attribution" : { ... },
+  "rights" : [ { ... }, { ... }],
+  "coverage" : { ... },
+  "descriptions" : [ { ... }, { ... } ],
+  "identifiers" : { ... }
+  "created" : ...,
+  "modified" : ...,
+  "repository" : { ... }
 
   ...possibility of extension elements...
 
@@ -1063,6 +1077,30 @@ value | The value of the qualifier. | value | string
   "value" : "..."
 }
 ```
+
+<a name="coverage"/>
+
+## 3.21 The "Coverage" Data Type
+
+The `gx:Coverage` XML type is used to (de)serialize the `http://gedcomx.org/v1/Coverage`
+data type.
+
+### properties
+
+name | description | XML property | XML type
+-----|-------------|--------------|---------
+spatial | The spatial (i.e., geographic) coverage. | spatial | [`PlaceReference`](#conclusion-place-reference)
+temporal | The temporal coverage. | temporal | [`Date`](#conclusion-date)
+
+### examples
+
+```json
+{
+  "spatial" : { ... },
+  "temporal" : { ... }
+}
+```
+
 
 
 # 4 JSON-Specific Data Types

--- a/specifications/xml-format-specification.md
+++ b/specifications/xml-format-specification.md
@@ -290,6 +290,13 @@ componentOf | A reference to the source that contains this source. | gx:componen
 titles | The display name(s) for this source. | gx:title | [`gx:TextValue`](#text-value)
 notes | A list of notes about a source | gx:note | [`gx:Note`](#note)
 attribution | The attribution of this source. | gx:attribution | [`gx:Attribution`](#attribution)
+rights  | The rights for this resource. | gx:rights | [`gx:ResourceReference`](#resource-reference)
+coverage | The coverage of the resource. | gx:coverage | [`gx:Coverage`](#coverage)
+descriptions | Human-readable descriptions of this source. | gx:description | [`gx:TextValue`](#text-value)
+identifiers | A list of identifiers for the resource being described. | gx:identifier | [`gx:Identifier`](#identifier-type)
+created | Timestamp of when the resource being described was created. | gx:created | xsd:dateTime
+modified | Timestamp of when the resource being described was modified. | gx:modified | xsd:dateTime
+repository | A reference to the repository that contains the described resource. | gx:repository | [`gx:ResourceReference`](#resource-reference)
 
 ### examples
 
@@ -317,6 +324,17 @@ attribution | The attribution of this source. | gx:attribution | [`gx:Attributio
     <gx:attribution>
       ...
     </gx:attribution>
+    <gx:rights resource="..."/>
+    ...
+    <gx:coverage>
+      ...
+    </gx:coverage>
+    <gx:description>...</gx:description>
+    ...
+    <gx:identifier>...</gx:identifier>
+    <gx:created>...</gx:created>
+    <gx:modified>...</gx:modified>
+    <gx:repository resource="..."/>
 
     <!-- possibility of extension elements -->
 
@@ -800,9 +818,9 @@ attribution | The attribution of this subject. | gx:attribution | [`gx:Attributi
       ...
     </gx:media>
     ...
-    <gx:identifiers>
+    <gx:identifier>
       ...
-    </gx:identifiers>
+    </gx:identifier>
     ...
     <gx:attribution>
       ...
@@ -1058,6 +1076,35 @@ value | The value of the qualifier. | (child text) | xsd:string
 
 ```xml
   <... name="http://gedcomx.org/QualifierName">...qualifier value...</...>
+```
+
+<a name="coverage"/>
+
+## 3.21 The "Coverage" Data Type
+
+The `gx:Coverage` XML type is used to (de)serialize the `http://gedcomx.org/v1/Coverage`
+data type.
+
+### properties
+
+name | description | XML property | XML type
+-----|-------------|--------------|---------
+spatial | The spatial (i.e., geographic) coverage. | gx:spatial | [`gx:PlaceReference`](#conclusion-place-reference)
+temporal | The temporal coverage. | gx:temporal | [`gx:Date`](#conclusion-date)
+
+### examples
+
+```xml
+  <...>
+    <gx:spatial>
+      ...
+    </gx:spatial>
+    <gx:temporal>
+      ...
+    </gx:temporal>
+
+    <!-- possibility of extension elements -->
+  </...>
 ```
 
 


### PR DESCRIPTION
The attached patch contains a proposal to support a bunch of new properties `SourceDescription` data type, including:
- rights
- coverage
- descriptions
- identifiers
- created
- modified
- repository

Comments are welcome.
