### PR TITLE
Proposal: Family

### DIFF
--- a/specifications/conceptual-model-specification.md
+++ b/specifications/conceptual-model-specification.md
@@ -648,7 +648,7 @@ This data type extends the following data type:
 name  | description | data type | constraints
 ------|-------------|-----------|------------
 parent1 | Reference to the first parent in the relationship. | [URI](#uri) | OPTIONAL. If provided, MUST resolve to an instance of [`http://gedcomx.org/v1/Person`](#person)
-parent1 | Reference to the second parent in the relationship. | [URI](#uri) | OPTIONAL. If provided, MUST resolve to an instance of [`http://gedcomx.org/v1/Person`](#person)
+parent2 | Reference to the second parent in the relationship. | [URI](#uri) | OPTIONAL. If provided, MUST resolve to an instance of [`http://gedcomx.org/v1/Person`](#person)
 children | The list of references to the children of this family. | List of [URI](#uri). Order is preserved. | OPTIONAL. If provided, each reference in the list MUST resolve to an instance of [`http://gedcomx.org/v1/Person`](#person).
 
 <a name="component-data-types"/>

--- a/specifications/conceptual-model-specification.md
+++ b/specifications/conceptual-model-specification.md
@@ -62,6 +62,7 @@ relationships, and sources.
   * [2.6 The "Document" Data Type](#document)
     * [2.6.1 Known Document Types](#known-document-types)
   * [2.7 The "PlaceDescription" Data Type](#place-description)
+  * [2.8 The "Family" Data Type](#family)
 * [3. Component-Level Data Types](#component-data-types)
   * [3.1 The "Identifier" Data Type](#identifier-type)
   * [3.2 The "Attribution" Data Type](#attribution)
@@ -623,6 +624,32 @@ latitude | Angular distance, in degrees, north or south of the Equator (0.0 degr
 longitude | Angular distance, in degrees, east or west of the Prime Meridian (0.0 degrees). | double | OPTIONAL.  If provided, MUST provide `latitude` also.  Values range from −180.0 degrees (west of the Meridian) to 180.0 degrees (east of the Meridian). It is assumed that descriptions that provide the same value for the `place` property share identical `latitude` values.
 temporalDescription | A description of the time period to which this place description is relevant. | [`http://gedcomx.org/v1/Date`](#conclusion-date) | OPTIONAL.
 spatialDescription | A reference to a geospatial description of this place. | [`URI`](#uri) | OPTIONAL. It is RECOMMENDED that this geospatial description resolve to a [KML](http://en.wikipedia.org/wiki/Keyhole_Markup_Language) document.
+
+<a name="family"/>
+
+## 2.8 The "Family" Data Type
+
+The `Family` data type describes a family, defined as no more than two parents and a list of children.
+
+### identifier
+
+The identifier for the `Family` data type is:
+
+`http://gedcomx.org/v1/Family`
+
+### extension
+
+This data type extends the following data type:
+
+`http://gedcomx.org/v1/Conclusion`
+
+### properties
+
+name  | description | data type | constraints
+------|-------------|-----------|------------
+parent1 | Reference to the first parent in the relationship. | [URI](#uri) | OPTIONAL. If provided, MUST resolve to an instance of [`http://gedcomx.org/v1/Person`](#person)
+parent1 | Reference to the second parent in the relationship. | [URI](#uri) | OPTIONAL. If provided, MUST resolve to an instance of [`http://gedcomx.org/v1/Person`](#person)
+children | The list of references to the children of this family. | List of [URI](#uri). Order is preserved. | OPTIONAL. If provided, each reference in the list MUST resolve to an instance of [`http://gedcomx.org/v1/Person`](#person).
 
 <a name="component-data-types"/>
 

--- a/specifications/json-format-specification.md
+++ b/specifications/json-format-specification.md
@@ -53,6 +53,7 @@ to serialize and deserialize the GEDCOM X Conceptual Model to and from
   * [2.5 The "Event" Data Type](#event)
   * [2.6 The "Document" Data Type](#document)
   * [2.7 The "PlaceDescription" Data Type](#place-description)
+  * [2.8 The "Family" Data Type](#family)
 * [3. Component-Level Data Types](#component-data-types)
   * [3.1 The "Identifier" Data Type](#identifier-type)
   * [3.2 The "Attribution" Data Type](#attribution)
@@ -577,6 +578,22 @@ spatialDescription | A reference to a geospatial description of this place. | sp
   }
 }
 ```
+
+<a name="family"/>
+
+## 2.8 The "Family" Data Type
+
+The JSON object used to (de)serialize the `http://gedcomx.org/v1/Family` data type
+is defined as follows:
+
+### properties
+
+name | description | JSON member | JSON object type
+-----|-------------|--------------|---------
+parent1 | Reference to the first parent in the family. | parent1 | [`ResourceReference`](#resource-reference)
+parent2 | Reference to the second parent in the family. | parent2 | [`ResourceReference`](#resource-reference)
+children | The list of references to the children of this family. | children | array of [`ResourceReference`](#resource-reference)
+
 
 <a name="component-data-types"/>
 
@@ -1222,6 +1239,7 @@ lang | The locale identifier for the data set. | lang | [IETF BCP 47](http://too
 attribution | The attribution of this data set. | attribution | [`Attribution`](#attribution) | OPTIONAL.
 persons | The list of persons contained in the data set. | persons | array of [`Person`](#person) | OPTIONAL.
 relationships | The list of relationships contained in the data set. | relationships | array of [`Relationship`](#relationship) | OPTIONAL.
+families | The list of families contained in the data set. | families | array of [`Family`](#family) | OPTIONAL.
 sourceDescriptions | The list of source descriptions contained in the data set. | sourceDescriptions | array of [`SourceDescription`](#source-description) | OPTIONAL.
 agents | The list of agents contained in the data set. | agents | array of [`Agent`](#agent) | OPTIONAL.
 events | The list of events contained in the data set. | events | array of [`Event`](#event) | OPTIONAL.
@@ -1238,6 +1256,7 @@ description | Reference to the description of this data set. | description | [`U
   "attribution" : { ... },
   "persons" : [ { ... }, { ... } ],
   "relationships" : [ { ... }, { ... }, ],
+  "families" : [ { ... }, { ... }, ],
   "sourceDescriptions" : [ { ... }, { ... } ],
   "agents" : [ { ... } , { ... } ],
   "events" : [ { ... } , { ... } ],
@@ -1266,6 +1285,7 @@ The following is an example of the structure of a GEDCOM X JSON Element:
   "attribution" : { ... },
   "persons" : [ { ... }, { ... } ],
   "relationships" : [ { ... }, { ... }, ],
+  "families" : [ { ... }, { ... }, ],
   "sourceDescriptions" : [ { ... }, { ... } ],
   "agents" : [ { ... } , { ... } ],
   "events" : [ { ... } , { ... } ],

--- a/specifications/xml-format-specification.md
+++ b/specifications/xml-format-specification.md
@@ -55,6 +55,7 @@ to serialize and deserialize the GEDCOM X Conceptual Model to and from
   * [2.5 The "Event" Data Type](#event)
   * [2.6 The "Document" Data Type](#document)
   * [2.7 The "PlaceDescription" Data Type](#place-description)
+  * [2.8 The "Family" Data Type](#family)
 * [3. Component-Level Data Types](#component-data-types)
   * [3.1 The "Identifier" Data Type](#identifier-type)
   * [3.2 The "Attribution" Data Type](#attribution)
@@ -569,6 +570,22 @@ spatialDescription | A reference to a geospatial description of this place. | gx
     ...
   </...>
 ```
+
+<a name="family"/>
+
+## 2.8 The "Family" Data Type
+
+The JSON object used to (de)serialize the `http://gedcomx.org/v1/Family` data type
+is defined as follows:
+
+### properties
+
+name | description | JSON member | JSON object type
+-----|-------------|--------------|---------
+parent1 | Reference to the first parent in the family. | parent1 | [`ResourceReference`](#resource-reference)
+parent2 | Reference to the second parent in the family. | parent2 | [`ResourceReference`](#resource-reference)
+children | The list of references to the children of this family. | children | array of [`ResourceReference`](#resource-reference)
+
 
 
 <a name="component-data-types"/>
@@ -1232,6 +1249,7 @@ lang | The locale identifier for the data set. | xml:lang (attribute) | [IETF BC
 attribution | The attribution of this data set. | gx:attribution | [`gx:Attribution`](#attribution) | OPTIONAL.
 persons | The list of persons contained in the data set. | gx:person | [`gx:Person`](#person) | OPTIONAL.
 relationships | The list of relationships contained in the data set. | gx:relationship | [`gx:Relationship`](#relationship) | OPTIONAL.
+families | The list of families contained in the data set. | gx:family | [`gx:Family`](#family) | OPTIONAL.
 sourceDescriptions | The list of source descriptions contained in the data set. | gx:sourceDescription | [`gx:SourceDescription`](#source-description) | OPTIONAL.
 agents | The list of agents contained in the data set. | gx:agent | [`gx:Agent`](#agent) | OPTIONAL.
 events | The list of events contained in the data set. | gx:event | [`gx:Event`](#event) | OPTIONAL.
@@ -1249,6 +1267,9 @@ description | Reference to the description of this data set. | description (attr
   ...
   <gx:relationship>...</gx:relationship>
   <gx:relationship>...</gx:relationship>
+  ...
+  <gx:family>...</gx:family>
+  <gx:family>...</gx:family>
   ...
   <gx:sourceDescription>...</gx:sourceDescription>
   <gx:sourceDescription>...</gx:sourceDescription>
@@ -1306,6 +1327,10 @@ The following is an example of the structure of a GEDCOM X XML Element:
 
   <relationship>...</relationship>
   <relationship>...</relationship>
+  ...
+
+  <family>...</family>
+  <family>...</family>
   ...
 
   <sourceDescription>...</sourceDescription>


### PR DESCRIPTION
The attached changes constitute the introduction of a new data type, `Family`, defined as no more than two parents and a list of children.

### properties

name  | description | data type | constraints
------|-------------|-----------|------------
parent1 | Reference to the first parent in the relationship. | [URI](#uri) | OPTIONAL. If provided, MUST resolve to an instance of [`http://gedcomx.org/v1/Person`](#person)
parent2 | Reference to the second parent in the relationship. | [URI](#uri) | OPTIONAL. If provided, MUST resolve to an instance of [`http://gedcomx.org/v1/Person`](#person)
children | The list of references to the children of this family. | List of [URI](#uri). Order is preserved. | OPTIONAL. If provided, each reference in the list MUST resolve to an instance of [`http://gedcomx.org/v1/Person`](#person).

Comments are welcome.