### PR TITLE
Proposal: Group

### DIFF
--- a/specifications/conceptual-model-specification.md
+++ b/specifications/conceptual-model-specification.md
@@ -1436,6 +1436,7 @@ name  | description | data type | constraints
 ------|-------------|-----------|------------
 person | Reference to the group participant. | [`URI`](#uri) | REQUIRED. MUST resolve to an instance of [`http://gedcomx.org/v1/Person`](#person).
 type | Enumerated value identifying the participant's role. | [Enumerated Value](#enumerated-value) | OPTIONAL. If provided, MUST identify a role type.
+date | The date of applicability of the role. | [`http://gedcomx.org/v1/Date`](#conclusion-date) | OPTIONAL.
 details | Details about the role of he participant in the group. | string | OPTIONAL.
 
 <a name="extracted-conclusion-constraints"/>

--- a/specifications/conceptual-model-specification.md
+++ b/specifications/conceptual-model-specification.md
@@ -62,6 +62,7 @@ relationships, and sources.
   * [2.6 The "Document" Data Type](#document)
     * [2.6.1 Known Document Types](#known-document-types)
   * [2.7 The "PlaceDescription" Data Type](#place-description)
+  * [2.8 The "Group" Data Type](#group)
 * [3. Component-Level Data Types](#component-data-types)
   * [3.1 The "Identifier" Data Type](#identifier-type)
   * [3.2 The "Attribution" Data Type](#attribution)
@@ -90,7 +91,8 @@ relationships, and sources.
     * [3.18.1 Known Name Part Types](#known-name-part-types)
   * [3.19 The "NameForm" Data Type](#name-form)
   * [3.20 The "Qualifier" Data Type](#qualifier)
-  * [3.21 The "Coverage" Data Type](#user-content-coverage)
+  * [3.21 The "Coverage" Data Type](#coverage)
+  * [3.22 The "GroupRole" Data Type](#conclusion-group-role)
 * [4. Extracted Conclusion Constraints](#extracted-conclusion-constraints)
   * [4.1 Persona](#persona)
 * [5. Extensibility](#extensibility)
@@ -624,6 +626,34 @@ latitude | Angular distance, in degrees, north or south of the Equator (0.0 degr
 longitude | Angular distance, in degrees, east or west of the Prime Meridian (0.0 degrees). | double | OPTIONAL.  If provided, MUST provide `latitude` also.  Values range from −180.0 degrees (west of the Meridian) to 180.0 degrees (east of the Meridian). It is assumed that descriptions that provide the same value for the `place` property share identical `latitude` values.
 temporalDescription | A description of the time period to which this place description is relevant. | [`http://gedcomx.org/v1/Date`](#conclusion-date) | OPTIONAL.
 spatialDescription | A reference to a geospatial description of this place. | [`URI`](#uri) | OPTIONAL. It is RECOMMENDED that this geospatial description resolve to a [KML](http://en.wikipedia.org/wiki/Keyhole_Markup_Language) document.
+
+<a name="group"/>
+
+## 2.8 The "Group" Data Type
+
+The `Group` data type describes a group of of persons. The concept of a "group" captures institutional associations between persons that may or may not
+have direct familial relations between each other. Examples of a group could include plantations, orphanages, or military units.
+
+### identifier
+
+The identifier for the `Group` data type is:
+
+`http://gedcomx.org/v1/Group`
+
+### extension
+
+This data type extends the following data type:
+
+`http://gedcomx.org/v1/Subject`
+
+### properties
+
+name  | description | data type | constraints
+------|-------------|-----------|------------
+names | A list of names of the group. | List of [`http://gedcomx.org/v1/TextValue`](#text-value). Order is preserved. | REQUIRED. The list MUST contain at least one name.
+date | The date of applicability of the group. | [`http://gedcomx.org/v1/Date`](#conclusion-date) | OPTIONAL.
+place | A reference to the place applicable to this group. | [`http://gedcomx.org/v1/PlaceReference`](#conclusion-place-reference) | OPTIONAL.
+roles | Information about how persons were associated with the group. | List of [`http://gedcomx.org/v1/GroupRole`](#conclusion-group-role). Order is preserved. | OPTIONAL.
 
 <a name="component-data-types"/>
 
@@ -1381,6 +1411,32 @@ name  | description | data type | constraints
 spatial | The spatial (i.e., geographic) coverage. | [`http://gedcomx.org/v1/PlaceReference`](#conclusion-place-reference) | OPTIONAL.
 temporal | The temporal coverage. | [`http://gedcomx.org/v1/Date`](#conclusion-date) | OPTIONAL.
 
+
+<a name="conclusion-group-role"/>
+
+## 3.22 The "GroupRole" Data Type
+
+The `GroupRole` data type defines a role of a person in a group.
+
+### identifier
+
+The identifier for the `GroupRole` data type is:
+
+`http://gedcomx.org/v1/GroupRole`
+
+### extension
+
+This data type extends the following data type:
+
+`http://gedcomx.org/v1/Conclusion`
+
+### properties
+
+name  | description | data type | constraints
+------|-------------|-----------|------------
+person | Reference to the group participant. | [`URI`](#uri) | REQUIRED. MUST resolve to an instance of [`http://gedcomx.org/v1/Person`](#person).
+type | Enumerated value identifying the participant's role. | [Enumerated Value](#enumerated-value) | OPTIONAL. If provided, MUST identify a role type.
+details | Details about the role of he participant in the group. | string | OPTIONAL.
 
 <a name="extracted-conclusion-constraints"/>
 

--- a/specifications/json-format-specification.md
+++ b/specifications/json-format-specification.md
@@ -1280,6 +1280,7 @@ name | description | JSON member | JSON object type
 -----|-------------|--------------|---------
 person | Reference to the group participant. | person | [`ResourceReference`](#resource-reference)
 type | URI identifying the participant's role. | type | [`URI`](#uri)
+date | The date of applicability of the role. | date | [`Date`](#conclusion-date)
 details | Details about the role of participant in the group. | details | string
 
 ### examples
@@ -1293,6 +1294,7 @@ details | Details about the role of participant in the group. | details | string
     "resource" : "http://identifier/for/person/1"
   },
   "type" : "...",
+  "date" : { /*...*/ },
   "details" : "..."
 }
 ```

--- a/specifications/json-format-specification.md
+++ b/specifications/json-format-specification.md
@@ -53,6 +53,7 @@ to serialize and deserialize the GEDCOM X Conceptual Model to and from
   * [2.5 The "Event" Data Type](#event)
   * [2.6 The "Document" Data Type](#document)
   * [2.7 The "PlaceDescription" Data Type](#place-description)
+  * [2.7 The "Group" Data Type](#group)
 * [3. Component-Level Data Types](#component-data-types)
   * [3.1 The "Identifier" Data Type](#identifier-type)
   * [3.2 The "Attribution" Data Type](#attribution)
@@ -75,6 +76,7 @@ to serialize and deserialize the GEDCOM X Conceptual Model to and from
   * [3.19 The "NameForm" Data Type](#name-form)
   * [3.20 The "Qualifier" Data Type](#qualifier)
   * [3.21 The "Coverage" Data Type](#coverage)
+  * [3.22 The "Coverage" Data Type](#conclusion-group-role)
 * [4. JSON-Specific Data Types](#json-specific-data-types)
   * [4.1 The URI](#uri)
   * [4.2 The "ResourceReference" Data Type](#resource-reference)
@@ -559,6 +561,70 @@ latitude | Angular distance, in degrees, north or south of the Equator. | latitu
 longitude | Angular distance, in degrees, east or west of the Prime Meridian. | longitude | number
 temporalDescription | A description of the time period to which this place description is relevant. | temporalDescription | [`Date`](#conclusion-date)
 spatialDescription | A reference to a geospatial description of this place. | spatialDescription | [`ResourceReference`](#resource-reference)
+
+### examples
+
+```javascript
+{
+
+  //...the members of [Subject](#subject)...,
+
+  "names" : [ {
+    "lang" : "en",
+    "value" : "Pope's Creek, Westmoreland, Virginia, United States"
+  } ,
+  {
+    "lang" : "zh",
+    "value" : "教皇的小河，威斯特摩兰，弗吉尼亚州，美国"
+  } ],
+  "type" : "http://identifier/for/the/place/type",
+  "place" : { "resource" : "..." },
+  "jurisdiction" : { "resource" : "..." },
+  "latitude" : "27.9883575",
+  "latitude" : "86.9252014",
+  "temporalDescription" : { /*...*/ },
+  "spatialDescription" : {
+    "resource" : "http://uri/for/KML/document"
+  }
+}
+```
+
+<a name="group"/>
+
+# 2.8 The "Group" Data Type
+
+The JSON object used to (de)serialize the [`http://gedcomx.org/v1/Group`](https://github.com/FamilySearch/gedcomx/blob/master/specifications/conceptual-model-specification.md#place-description) data type
+is defined as follows:
+
+### properties
+
+name | description | JSON member | JSON object type
+-----|-------------|--------------|---------
+names | A list of names of the group. | names | array of [`TextValue`](#text-value)
+date | The date of applicability of the group. | date | [`Date`](#conclusion-date)
+place | The place of applicability of the group. | place | [`PlaceReference`](#conclusion-place-reference)
+roles | Information about how persons participated in the event. | roles | array of [`EventRole`](#conclusion-event-role)
+
+### examples
+
+```javascript
+{
+
+  //...the members of [Subject](#subject)...,
+
+  "names" : [ {
+    "lang" : "en",
+    "value" : "Monticello Plantation"
+  } ,
+  {
+    "lang" : "zh",
+    "value" : "monticello种植园"
+  } ],
+  "date" : { /*...*/ },
+  "place" : { /*...*/ },
+  "roles" : [ { /*...*/ }, { /*...*/ } ]
+}
+```
 
 ### examples
 
@@ -1203,6 +1269,33 @@ temporal | The temporal coverage. | temporal | [`Date`](#conclusion-date)
 }
 ```
 
+## 3.22 The "GroupRole" Data Type
+
+The JSON object used to (de)serialize the [`http://gedcomx.org/v1/GroupRole`](https://github.com/FamilySearch/gedcomx/blob/master/specifications/conceptual-model-specification.md#conclusion-group-role)
+data type is defined as follows:
+
+### properties
+
+name | description | JSON member | JSON object type
+-----|-------------|--------------|---------
+person | Reference to the group participant. | person | [`ResourceReference`](#resource-reference)
+type | URI identifying the participant's role. | type | [`URI`](#uri)
+details | Details about the role of participant in the group. | details | string
+
+### examples
+
+```javascript
+{
+
+  //...the members of [Conclusion](#conclusion)...,
+
+  "person" : {
+    "resource" : "http://identifier/for/person/1"
+  },
+  "type" : "...",
+  "details" : "..."
+}
+```
 
 <a name="json-specific-data-types"/>
 

--- a/specifications/xml-format-specification.md
+++ b/specifications/xml-format-specification.md
@@ -76,6 +76,8 @@ to serialize and deserialize the GEDCOM X Conceptual Model to and from
   * [3.18 The "NamePart" Data Type](#name-part)
   * [3.19 The "NameForm" Data Type](#name-form)
   * [3.20 The "Qualifier" Data Type](#qualifier)
+  * [3.22 The "Coverage" Data Type](#coverage)
+  * [3.23 The "Coverage" Data Type](#conclusion-group-role)
 * [4. XML-Specific Data Types](#xml-data-types)
   * [4.1 The URI](#uri)
   * [4.2 The "ResourceReference" Data Type](#resource-reference)
@@ -565,6 +567,42 @@ spatialDescription | A reference to a geospatial description of this place. | gx
       ...
     </gx:temporalDescription>
     <gx:spatialDescription resource="http://uri/for/KML/document"/>
+    ...
+  </...>
+```
+
+## 2.8 The "Group" Data Type
+
+The `gx:Group` XML type is used to (de)serialize the `http://gedcomx.org/v1/Group` data type.
+
+
+### properties
+
+name | description | XML property | XML type
+-----|-------------|--------------|---------
+names | A list of names of the group. | gx:name | [`gx:TextValue`](#text-value)
+date | The date of applicability of the group. | gx:date | [`gx:Date`](#conclusion-date)
+place | The place of applicability of the group. | gx:place | [`gx:PlaceReference`](#conclusion-place-reference)
+roles | Information about how persons were associated with the group. | gx:role | [`gx:GroupRole`](#conclusion-group-role)
+
+### examples
+
+```xml
+  <...>
+
+    <!-- ...the members of [gx:Subject](#subject)... -->
+
+    <gx:name lang="en">Monticello Plantation</gx:name>
+    <gx:name lang="zh">monticello种植园</gx:name>
+    <gx:date>
+      ...
+    </gx:date>
+    <gx:place>
+      ...
+    </gx:place>
+    <gx:role>
+      ...
+    </gx:role>
     ...
   </...>
 ```
@@ -1183,6 +1221,33 @@ temporal | The temporal coverage. | gx:temporal | [`gx:Date`](#conclusion-date)
     </gx:temporal>
 
     <!-- possibility of extension elements -->
+  </...>
+```
+
+<a name="conclusion-group-role"/>
+
+## 3.22 The "GroupRole" Data Type
+
+The `gx:GroupRole` XML type is used to (de)serialize the `http://gedcomx.org/v1/GroupRole`
+data type.
+
+### properties
+
+name | description | XML property | XML type
+-----|-------------|--------------|---------
+person | Reference to the group participant. | gx:person | [`gx:ResourceReference`](#resource-reference)
+type | URI identifying the participant's role. | type (attribute) | [`URI`](#uri)
+details | Details about the role of participant in the group. | gx:details | xsd:string
+
+### examples
+
+```xml
+  <... id="local_id" type="...">
+
+    <!-- ...the members of [gx:Conclusion](#conclusion)... -->
+
+    <gx:person resource="http://identifier/for/person/1"/>
+    <gx:details>...</gx:details>
   </...>
 ```
 

--- a/specifications/xml-format-specification.md
+++ b/specifications/xml-format-specification.md
@@ -1237,6 +1237,7 @@ name | description | XML property | XML type
 -----|-------------|--------------|---------
 person | Reference to the group participant. | gx:person | [`gx:ResourceReference`](#resource-reference)
 type | URI identifying the participant's role. | type (attribute) | [`URI`](#uri)
+date | The date of applicability of the role. | gx:date | [`gx:Date`](#conclusion-date)
 details | Details about the role of participant in the group. | gx:details | xsd:string
 
 ### examples
@@ -1247,6 +1248,9 @@ details | Details about the role of participant in the group. | gx:details | xsd
     <!-- ...the members of [gx:Conclusion](#conclusion)... -->
 
     <gx:person resource="http://identifier/for/person/1"/>
+    <gx:date>
+      ...
+    </gx:date>
     <gx:details>...</gx:details>
   </...>
 ```


### PR DESCRIPTION
The attached changes constitute a proposal for the introduction of a new data type, `Group`.

Comments are welcome.

## `Group` Data Type

The `Group` data type is defined as a group of persons. The concept of a "group" captures institutional associations between persons that may or may not have direct familial relations between each other. Examples of a group could include plantations, orphanages, or military units.

### properties

name  | description | data type | constraints
------|-------------|-----------|------------
names | A list of names of the group. | List of [`http://gedcomx.org/v1/TextValue`](#text-value). Order is preserved. | REQUIRED. The list MUST contain at least one name.
date | The date of applicability of the group. | [`http://gedcomx.org/v1/Date`](#conclusion-date) | OPTIONAL.
place | A reference to the place applicable to this group. | [`http://gedcomx.org/v1/PlaceReference`](#conclusion-place-reference) | OPTIONAL.
roles | Information about how persons were associated with the group. | List of [`http://gedcomx.org/v1/GroupRole`](#conclusion-group-role). Order is preserved. | OPTIONAL.

## `GroupRole` Data Type

In order to support the association of a person to a group, a new data type `GroupRole` must be defined.

Persons can be associated with multiple groups. Groups can have multiple persons associated.

### properties

name  | description | data type | constraints
------|-------------|-----------|------------
person | Reference to the group participant. | [`URI`](#uri) | REQUIRED. MUST resolve to an instance of [`http://gedcomx.org/v1/Person`](#person).
type | Enumerated value identifying the participant's role. | [Enumerated Value](#enumerated-value) | OPTIONAL. If provided, MUST identify a role type.
details | Details about the role of he participant in the group. | string | OPTIONAL.
